### PR TITLE
Convert chart time to local timezone

### DIFF
--- a/apps/data/components/FractalChartControlled.tsx
+++ b/apps/data/components/FractalChartControlled.tsx
@@ -264,6 +264,18 @@ export default function FractalChartControlled({
         visible: true,
         timeVisible: true,
         secondsVisible: false,
+        tickMarkFormatter: (time: Time) => {
+          // Convert the time (which is in seconds since epoch) to milliseconds
+          const date = new Date((time as number) * 1000)
+          // Format the date in the user's local time zone
+          return date.toLocaleString(undefined, {
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false, // Use 24-hour format
+          })
+        },
       },
       crosshair: {
         mode: 0, // Normal mode: we'll set Y explicitly via setCrosshairPosition


### PR DESCRIPTION
Display chart x-axis time in the user's local time zone for better user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3b6b4a2-f7bd-41e6-b4af-c61247ce762f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3b6b4a2-f7bd-41e6-b4af-c61247ce762f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

