### PR TITLE
ma indicator

### DIFF
--- a/apps/strength/charts/SyncedCharts.tsx
+++ b/apps/strength/charts/SyncedCharts.tsx
@@ -74,10 +74,10 @@ function getAggregationCacheKey(
 type AggregationCache = Map<
   string,
   {
-    strength: LineData<Time>[] | null
-    price: LineData<Time>[] | null
-    intervalStrength: Record<string, LineData<Time>[]>
-    tickerPrice: Record<string, LineData<Time>[]>
+    strengthAverage: LineData<Time>[] | null
+    priceAverage: LineData<Time>[] | null
+    strengthIntervals: Record<string, LineData<Time>[]>
+    priceTickers: Record<string, LineData<Time>[]>
     timestamp: number // When this was cached
   }
 >
@@ -119,23 +119,23 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
     chartTickers,
     timeRange,
     setTimeRange,
-    setAggregatedStrengthData,
-    setAggregatedPriceData,
-    setIntervalStrengthData,
-    setTickerPriceData,
+    setStrengthAverage,
+    setPriceAverage,
+    setStrengthIntervals,
+    setPriceTickers,
   } = useChartControlsStore()
 
   // Local state for chart rendering control
   const [chartData, setChartData] = useState<{
-    strength: LineData<Time>[] | null
-    price: LineData<Time>[] | null
-    intervalStrength: Record<string, LineData<Time>[]>
-    tickerPrice: Record<string, LineData<Time>[]>
+    strengthAverage: LineData<Time>[] | null
+    priceAverage: LineData<Time>[] | null
+    strengthIntervals: Record<string, LineData<Time>[]>
+    priceTickers: Record<string, LineData<Time>[]>
   }>({
-    strength: null,
-    price: null,
-    intervalStrength: {},
-    tickerPrice: {},
+    strengthAverage: null,
+    priceAverage: null,
+    strengthIntervals: {},
+    priceTickers: {},
   })
 
   // Track which dataVersion the current chartData corresponds to
@@ -222,10 +222,10 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
 
       // Update local chart data
       const newChartData = {
-        strength: result.strengthData,
-        price: result.priceData,
-        intervalStrength: result.intervalStrengthData,
-        tickerPrice: result.tickerPriceData,
+        strengthAverage: result.strengthAverage,
+        priceAverage: result.priceAverage,
+        strengthIntervals: result.strengthIntervals,
+        priceTickers: result.priceTickers,
       }
 
       setChartData(newChartData)
@@ -244,10 +244,10 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
       }
 
       // Also update store for any external consumers
-      setAggregatedStrengthData(result.strengthData)
-      setAggregatedPriceData(result.priceData)
-      setIntervalStrengthData(result.intervalStrengthData)
-      setTickerPriceData(result.tickerPriceData)
+      setStrengthAverage(result.strengthAverage)
+      setPriceAverage(result.priceAverage)
+      setStrengthIntervals(result.strengthIntervals)
+      setPriceTickers(result.priceTickers)
 
       if (processingTimeMs > 100) {
         console.log(
@@ -260,10 +260,10 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
     [
       chartTickers,
       interval,
-      setAggregatedStrengthData,
-      setAggregatedPriceData,
-      setIntervalStrengthData,
-      setTickerPriceData,
+      setStrengthAverage,
+      setPriceAverage,
+      setStrengthIntervals,
+      setPriceTickers,
     ]
   )
 
@@ -311,25 +311,25 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
     // This prevents showing old data while new data loads
     if (chartDataVersionRef.current !== dataVersion) {
       setChartData({
-        strength: null,
-        price: null,
-        intervalStrength: {},
-        tickerPrice: {},
+        strengthAverage: null,
+        priceAverage: null,
+        strengthIntervals: {},
+        priceTickers: {},
       })
 
       // Clear store data too
-      setAggregatedStrengthData(null)
-      setAggregatedPriceData(null)
-      setIntervalStrengthData({})
-      setTickerPriceData({})
+      setStrengthAverage(null)
+      setPriceAverage(null)
+      setStrengthIntervals({})
+      setPriceTickers({})
     }
   }, [
     dataVersion,
     setValidDataVersion,
-    setAggregatedStrengthData,
-    setAggregatedPriceData,
-    setIntervalStrengthData,
-    setTickerPriceData,
+    setStrengthAverage,
+    setPriceAverage,
+    setStrengthIntervals,
+    setPriceTickers,
   ])
 
   /**
@@ -347,12 +347,12 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
       if (age < CACHE_MAX_AGE_MS) {
         // Use cached data immediately for instant display
         // Fresh aggregation will update this shortly
-        if (chartData.strength === null) {
+        if (chartData.strengthAverage === null) {
           setChartData({
-            strength: cached.strength,
-            price: cached.price,
-            intervalStrength: cached.intervalStrength,
-            tickerPrice: cached.tickerPrice,
+            strengthAverage: cached.strengthAverage,
+            priceAverage: cached.priceAverage,
+            strengthIntervals: cached.strengthIntervals,
+            priceTickers: cached.priceTickers,
           })
         }
       } else {
@@ -452,20 +452,20 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
    * Effect: Calculate time range when data is ready
    */
   useEffect(() => {
-    if (!chartData.strength || chartData.strength.length === 0) return
+    if (!chartData.strengthAverage || chartData.strengthAverage.length === 0) return
 
     const newRange = calculateTimeRange(rawData, parseInt(hoursBack))
     if (newRange && newRange.from < newRange.to) {
       setTimeRange(newRange)
     }
-  }, [hoursBack, rawData, chartData.strength, setTimeRange])
+  }, [hoursBack, rawData, chartData.strengthAverage, setTimeRange])
 
   /**
    * Determine what to render based on state
    */
   const showLoading = dataState === 'loading'
   const showError = error && dataState !== 'loading'
-  const showChart = chartData.strength !== null
+  const showChart = chartData.strengthAverage !== null
 
   // Only pass timeRange to chart when we have valid data
   const chartTimeRange = showChart ? timeRange : undefined
@@ -512,10 +512,10 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
               </span>
             </span>
           }
-          strengthData={chartData.strength}
-          priceData={chartData.price}
-          intervalStrengthData={chartData.intervalStrength}
-          tickerPriceData={chartData.tickerPrice}
+          strengthAverage={chartData.strengthAverage}
+          priceAverage={chartData.priceAverage}
+          strengthIntervals={chartData.strengthIntervals}
+          priceTickers={chartData.priceTickers}
           tickers={chartTickers}
           width={
             typeof window !== 'undefined'

--- a/apps/strength/charts/SyncedCharts.tsx
+++ b/apps/strength/charts/SyncedCharts.tsx
@@ -15,7 +15,7 @@ import {
 import { SCALE_FACTOR } from '@/constants'
 import { LineData, Time } from 'lightweight-charts'
 import { SCROLL_PAUSE_RESUME_MS } from './constants'
-import { computeStrengthIndicator } from './lib/computeIndicator'
+import { computeStrengthIndicator } from './lib/computeStrengthIndicator'
 
 export interface SyncedChartsProps {
   availableHeight: number

--- a/apps/strength/charts/SyncedCharts.tsx
+++ b/apps/strength/charts/SyncedCharts.tsx
@@ -452,7 +452,8 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
    * Effect: Calculate time range when data is ready
    */
   useEffect(() => {
-    if (!chartData.strengthAverage || chartData.strengthAverage.length === 0) return
+    if (!chartData.strengthAverage || chartData.strengthAverage.length === 0)
+      return
 
     const newRange = calculateTimeRange(rawData, parseInt(hoursBack))
     if (newRange && newRange.from < newRange.to) {
@@ -512,10 +513,10 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
               </span>
             </span>
           }
-          strengthAverage={chartData.strengthAverage}
-          priceAverage={chartData.priceAverage}
-          strengthIntervals={chartData.strengthIntervals}
-          priceTickers={chartData.priceTickers}
+          strengthAverageData={chartData.strengthAverage}
+          priceAverageData={chartData.priceAverage}
+          strengthIntervalsData={chartData.strengthIntervals}
+          priceTickersData={chartData.priceTickers}
           tickers={chartTickers}
           width={
             typeof window !== 'undefined'

--- a/apps/strength/charts/SyncedCharts.tsx
+++ b/apps/strength/charts/SyncedCharts.tsx
@@ -15,6 +15,7 @@ import {
 import { SCALE_FACTOR } from '@/constants'
 import { LineData, Time } from 'lightweight-charts'
 import { SCROLL_PAUSE_RESUME_MS } from './constants'
+import { computeStrengthIndicator } from './lib/computeIndicator'
 
 export interface SyncedChartsProps {
   availableHeight: number
@@ -78,6 +79,7 @@ type AggregationCache = Map<
     priceAverage: LineData<Time>[] | null
     strengthIntervals: Record<string, LineData<Time>[]>
     priceTickers: Record<string, LineData<Time>[]>
+    strengthIndicator: LineData<Time>[] | null
     timestamp: number // When this was cached
   }
 >
@@ -123,6 +125,7 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
     setPriceAverage,
     setStrengthIntervals,
     setPriceTickers,
+    setStrengthIndicator,
   } = useChartControlsStore()
 
   // Local state for chart rendering control
@@ -131,11 +134,13 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
     priceAverage: LineData<Time>[] | null
     strengthIntervals: Record<string, LineData<Time>[]>
     priceTickers: Record<string, LineData<Time>[]>
+    strengthIndicator: LineData<Time>[] | null
   }>({
     strengthAverage: null,
     priceAverage: null,
     strengthIntervals: {},
     priceTickers: {},
+    strengthIndicator: null,
   })
 
   // Track which dataVersion the current chartData corresponds to
@@ -220,12 +225,16 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
       // Update the version this chart data corresponds to
       chartDataVersionRef.current = resultDataVersion
 
+      // Compute indicator from strength average
+      const strengthIndicator = computeStrengthIndicator(result.strengthAverage)
+
       // Update local chart data
       const newChartData = {
         strengthAverage: result.strengthAverage,
         priceAverage: result.priceAverage,
         strengthIntervals: result.strengthIntervals,
         priceTickers: result.priceTickers,
+        strengthIndicator,
       }
 
       setChartData(newChartData)
@@ -233,7 +242,11 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
       // Cache the results for instant ticker switching
       const cacheKey = getAggregationCacheKey(chartTickers, interval)
       aggregationCache.set(cacheKey, {
-        ...newChartData,
+        strengthAverage: newChartData.strengthAverage,
+        priceAverage: newChartData.priceAverage,
+        strengthIntervals: newChartData.strengthIntervals,
+        priceTickers: newChartData.priceTickers,
+        strengthIndicator: newChartData.strengthIndicator,
         timestamp: Date.now(),
       })
 
@@ -248,6 +261,7 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
       setPriceAverage(result.priceAverage)
       setStrengthIntervals(result.strengthIntervals)
       setPriceTickers(result.priceTickers)
+      setStrengthIndicator(strengthIndicator)
 
       if (processingTimeMs > 100) {
         console.log(
@@ -264,6 +278,7 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
       setPriceAverage,
       setStrengthIntervals,
       setPriceTickers,
+      setStrengthIndicator,
     ]
   )
 
@@ -315,6 +330,7 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
         priceAverage: null,
         strengthIntervals: {},
         priceTickers: {},
+        strengthIndicator: null,
       })
 
       // Clear store data too
@@ -322,6 +338,7 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
       setPriceAverage(null)
       setStrengthIntervals({})
       setPriceTickers({})
+      setStrengthIndicator(null)
     }
   }, [
     dataVersion,
@@ -330,6 +347,7 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
     setPriceAverage,
     setStrengthIntervals,
     setPriceTickers,
+    setStrengthIndicator,
   ])
 
   /**
@@ -353,6 +371,7 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
             priceAverage: cached.priceAverage,
             strengthIntervals: cached.strengthIntervals,
             priceTickers: cached.priceTickers,
+            strengthIndicator: cached.strengthIndicator,
           })
         }
       } else {
@@ -517,6 +536,7 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
           priceAverageData={chartData.priceAverage}
           strengthIntervalsData={chartData.strengthIntervals}
           priceTickersData={chartData.priceTickers}
+          strengthIndicatorData={chartData.strengthIndicator}
           tickers={chartTickers}
           width={
             typeof window !== 'undefined'

--- a/apps/strength/charts/components/Chart.tsx
+++ b/apps/strength/charts/components/Chart.tsx
@@ -24,7 +24,7 @@ import classes from '../classes.module.scss'
 import { prepareDataWithRequiredTimestamps } from '../lib/primitives/forwardFillData'
 import { TIME_RANGE_HIGHLIGHTS } from '../constants'
 import {
-  strengthIntervals as STRENGTH_INTERVALS,
+  strengthIntervalsAll as STRENGTH_INTERVALS,
   StrengthIntervalsData,
   PriceTickersData,
   useChartControlsStore,
@@ -34,10 +34,10 @@ import { COLORS } from '../constants'
 interface ChartProps {
   heading: string | React.ReactNode
   name: string
-  strengthAverage: LineData[] | null
-  priceAverage?: LineData[] | null
-  strengthIntervals?: StrengthIntervalsData
-  priceTickers?: PriceTickersData
+  strengthAverageData: LineData[] | null
+  priceAverageData?: LineData[] | null
+  strengthIntervalsData?: StrengthIntervalsData
+  priceTickersData?: PriceTickersData
   tickers?: string[]
   width: number
   height: number
@@ -60,10 +60,10 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
     {
       heading,
       name,
-      strengthAverage,
-      priceAverage,
-      strengthIntervals,
-      priceTickers,
+      strengthAverageData: strengthAverage,
+      priceAverageData: priceAverage,
+      strengthIntervalsData: strengthIntervals,
+      priceTickersData: priceTickers,
       tickers = [],
       width,
       height,

--- a/apps/strength/charts/components/Chart.tsx
+++ b/apps/strength/charts/components/Chart.tsx
@@ -24,9 +24,9 @@ import classes from '../classes.module.scss'
 import { prepareDataWithRequiredTimestamps } from '../lib/primitives/forwardFillData'
 import { TIME_RANGE_HIGHLIGHTS } from '../constants'
 import {
-  strengthIntervals,
-  IntervalStrengthData,
-  TickerPriceData,
+  strengthIntervals as STRENGTH_INTERVALS,
+  StrengthIntervalsData,
+  PriceTickersData,
   useChartControlsStore,
 } from '../state/useChartControlsStore'
 import { COLORS } from '../constants'
@@ -34,10 +34,10 @@ import { COLORS } from '../constants'
 interface ChartProps {
   heading: string | React.ReactNode
   name: string
-  strengthData: LineData[] | null
-  priceData?: LineData[] | null
-  intervalStrengthData?: IntervalStrengthData
-  tickerPriceData?: TickerPriceData
+  strengthAverage: LineData[] | null
+  priceAverage?: LineData[] | null
+  strengthIntervals?: StrengthIntervalsData
+  priceTickers?: PriceTickersData
   tickers?: string[]
   width: number
   height: number
@@ -48,10 +48,10 @@ interface ChartProps {
 
 export interface ChartRef {
   chart: IChartApi | null
-  strengthSeries: ISeriesApi<'Line'> | null
-  priceSeries?: ISeriesApi<'Line'> | null
-  intervalSeries?: Record<string, ISeriesApi<'Line'>>
-  tickerSeries?: Record<string, ISeriesApi<'Line'>>
+  strengthAverageSeries: ISeriesApi<'Line'> | null
+  priceAverageSeries?: ISeriesApi<'Line'> | null
+  strengthIntervalSeries?: Record<string, ISeriesApi<'Line'>>
+  priceTickerSeries?: Record<string, ISeriesApi<'Line'>>
   container: HTMLDivElement | null
 }
 
@@ -60,10 +60,10 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
     {
       heading,
       name,
-      strengthData,
-      priceData,
-      intervalStrengthData,
-      tickerPriceData,
+      strengthAverage,
+      priceAverage,
+      strengthIntervals,
+      priceTickers,
       tickers = [],
       width,
       height,
@@ -83,18 +83,20 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
 
     const containerRef = useRef<HTMLDivElement>(null)
     const chartRef = useRef<IChartApi | null>(null)
-    const strengthSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
-    const priceSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
-    const intervalSeriesRef = useRef<Record<string, ISeriesApi<'Line'>>>({})
-    const tickerSeriesRef = useRef<Record<string, ISeriesApi<'Line'>>>({})
+    const strengthAverageSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
+    const priceAverageSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
+    const strengthIntervalSeriesRef = useRef<
+      Record<string, ISeriesApi<'Line'>>
+    >({})
+    const priceTickerSeriesRef = useRef<Record<string, ISeriesApi<'Line'>>>({})
     const zeroLineSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
     const plus100LineSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
     const minus100LineSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
     const hasInitialized = useRef(false)
-    const lastDataRef = useRef<LineData[] | null>(null)
-    const lastSecondDataRef = useRef<LineData[] | null>(null)
-    const lastIntervalDataRef = useRef<IntervalStrengthData>({})
-    const lastTickerDataRef = useRef<TickerPriceData>({})
+    const lastStrengthAverageRef = useRef<LineData[] | null>(null)
+    const lastPriceAverageRef = useRef<LineData[] | null>(null)
+    const lastStrengthIntervalsRef = useRef<StrengthIntervalsData>({})
+    const lastPriceTickersRef = useRef<PriceTickersData>({})
 
     // Use extracted hooks
     const { createTimeMarkers, markersInitialized } = useTimeMarkers()
@@ -102,10 +104,10 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
 
     useImperativeHandle(ref, () => ({
       chart: chartRef.current,
-      strengthSeries: strengthSeriesRef.current,
-      priceSeries: priceSeriesRef.current,
-      intervalSeries: intervalSeriesRef.current,
-      tickerSeries: tickerSeriesRef.current,
+      strengthAverageSeries: strengthAverageSeriesRef.current,
+      priceAverageSeries: priceAverageSeriesRef.current,
+      strengthIntervalSeries: strengthIntervalSeriesRef.current,
+      priceTickerSeries: priceTickerSeriesRef.current,
       container: containerRef.current,
     }))
 
@@ -155,28 +157,28 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
       })
       minus100LineSeriesRef.current = minus100LineSeries
 
-      // Price - uses 'right' scale (default)
+      // Price average - uses 'right' scale (default)
       // Always create the series, even if data doesn't exist yet
-      const priceSeries = chart.addSeries(LineSeries, {
+      const priceAverageSeries = chart.addSeries(LineSeries, {
         ...getLineSeriesConfig(),
         lineWidth: 2,
         color: COLORS.price,
         priceScaleId: 'right',
       })
-      priceSeriesRef.current = priceSeries
+      priceAverageSeriesRef.current = priceAverageSeries
 
-      // Strength - uses 'left' scale
-      const strengthSeries = chart.addSeries(LineSeries, {
+      // Strength average - uses 'left' scale
+      const strengthAverageSeries = chart.addSeries(LineSeries, {
         ...getLineSeriesConfig(),
         lineWidth: 2,
         color: COLORS.strength,
         priceScaleId: 'left',
       })
-      strengthSeriesRef.current = strengthSeries
+      strengthAverageSeriesRef.current = strengthAverageSeries
 
-      // Strength intervals - uses 'left' scale to compare with Strength series
+      // Strength interval series - uses 'left' scale to compare with strength average
       // These are created once and data is set/updated later
-      strengthIntervals.forEach((interval) => {
+      STRENGTH_INTERVALS.forEach((interval) => {
         const intervalSeries = chart.addSeries(LineSeries, {
           ...getLineSeriesConfig(),
           lineWidth: interval === '181' && !showStrengthLine ? 2 : 1,
@@ -184,24 +186,24 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
             interval === '181' && !showStrengthLine
               ? COLORS.strength
               : COLORS.strength_i,
-          priceScaleId: 'left', // Use same scale as aggregated strength
+          priceScaleId: 'left', // Use same scale as strength average
         })
-        intervalSeriesRef.current[interval] = intervalSeries
+        strengthIntervalSeriesRef.current[interval] = intervalSeries
       })
 
       // Set initial data if available
-      if (strengthData) {
-        strengthSeries.setData(strengthData)
+      if (strengthAverage) {
+        strengthAverageSeries.setData(strengthAverage)
       }
-      if (priceData && priceSeriesRef.current) {
-        priceSeriesRef.current.setData(priceData)
+      if (priceAverage && priceAverageSeriesRef.current) {
+        priceAverageSeriesRef.current.setData(priceAverage)
       }
 
-      // Set initial interval data if available
-      if (intervalStrengthData) {
-        Object.entries(intervalStrengthData).forEach(([interval, data]) => {
-          if (data && intervalSeriesRef.current[interval]) {
-            intervalSeriesRef.current[interval].setData(data)
+      // Set initial strength intervals data if available
+      if (strengthIntervals) {
+        Object.entries(strengthIntervals).forEach(([interval, data]) => {
+          if (data && strengthIntervalSeriesRef.current[interval]) {
+            strengthIntervalSeriesRef.current[interval].setData(data)
           }
         })
       }
@@ -214,44 +216,44 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
       return () => {
         chart.remove()
         chartRef.current = null
-        strengthSeriesRef.current = null
-        priceSeriesRef.current = null
+        strengthAverageSeriesRef.current = null
+        priceAverageSeriesRef.current = null
         zeroLineSeriesRef.current = null
         plus100LineSeriesRef.current = null
         minus100LineSeriesRef.current = null
-        intervalSeriesRef.current = {}
-        tickerSeriesRef.current = {}
+        strengthIntervalSeriesRef.current = {}
+        priceTickerSeriesRef.current = {}
         hasInitialized.current = false
       }
     }, []) // Only run once on mount
 
-    // Update first series (strength) data
+    // Update strength average series data
     useEffect(() => {
       if (
-        !strengthSeriesRef.current ||
-        !strengthData ||
+        !strengthAverageSeriesRef.current ||
+        !strengthAverage ||
         !hasInitialized.current
       )
         return
 
       try {
-        const prevData = lastDataRef.current
+        const prevData = lastStrengthAverageRef.current
 
         // Apply forward-fill to ensure time range boundaries exist
         const currentData = prepareDataWithRequiredTimestamps(
-          strengthData,
+          strengthAverage,
           TIME_RANGE_HIGHLIGHTS
         )
 
         // Use efficient update strategy
         const updated = updateSeriesEfficiently(
-          strengthSeriesRef.current,
+          strengthAverageSeriesRef.current,
           currentData,
           prevData
         )
 
         if (updated) {
-          lastDataRef.current = currentData // Don't spread - keep reference for comparison
+          lastStrengthAverageRef.current = currentData // Don't spread - keep reference for comparison
 
           // Update horizontal line series to span the full data range
           // Only needs start and end points to draw horizontal lines
@@ -287,7 +289,7 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
 
         // Create time markers on first data load
         if (!markersInitialized.current && currentData.length > 0) {
-          createTimeMarkers(strengthSeriesRef.current, currentData)
+          createTimeMarkers(strengthAverageSeriesRef.current, currentData)
         }
 
         // Apply time range on first data load (when we had no previous data)
@@ -304,8 +306,8 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
           requestAnimationFrame(() => {
             if (
               chartRef.current &&
-              lastDataRef.current &&
-              lastDataRef.current.length > 0 &&
+              lastStrengthAverageRef.current &&
+              lastStrengthAverageRef.current.length > 0 &&
               timeRange &&
               timeRange.from < timeRange.to
             ) {
@@ -323,57 +325,61 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
           })
         }
       } catch (error) {
-        console.warn('Failed to update strength data:', error)
+        console.warn('Failed to update strength average data:', error)
       }
-    }, [strengthData, timeRange, name])
+    }, [strengthAverage, timeRange, name])
 
-    // Update second series (price) data
+    // Update price average series data
     useEffect(() => {
-      if (!priceSeriesRef.current || !priceData || !hasInitialized.current)
+      if (
+        !priceAverageSeriesRef.current ||
+        !priceAverage ||
+        !hasInitialized.current
+      )
         return
 
       try {
-        const prevData = lastSecondDataRef.current
+        const prevData = lastPriceAverageRef.current
 
         // Apply forward-fill to ensure time range boundaries exist
         const currentData = prepareDataWithRequiredTimestamps(
-          priceData,
+          priceAverage,
           TIME_RANGE_HIGHLIGHTS
         )
 
         // Use efficient update strategy
         const updated = updateSeriesEfficiently(
-          priceSeriesRef.current,
+          priceAverageSeriesRef.current,
           currentData,
           prevData
         )
 
         if (updated) {
-          lastSecondDataRef.current = currentData
+          lastPriceAverageRef.current = currentData
         }
       } catch (error) {
-        console.warn('Failed to update price data:', error)
+        console.warn('Failed to update price average data:', error)
       }
-    }, [priceData, name])
+    }, [priceAverage, name])
 
-    // Update interval series data
+    // Update strength interval series data
     // ALWAYS update data, control visibility separately via series.applyOptions
     useEffect(() => {
       if (!hasInitialized.current) return
 
       try {
-        strengthIntervals.forEach((interval) => {
-          const series = intervalSeriesRef.current[interval]
+        STRENGTH_INTERVALS.forEach((interval) => {
+          const series = strengthIntervalSeriesRef.current[interval]
           if (!series) return
 
-          const data = intervalStrengthData?.[interval]
-          const prevData = lastIntervalDataRef.current[interval]
+          const data = strengthIntervals?.[interval]
+          const prevData = lastStrengthIntervalsRef.current[interval]
 
           if (!data) {
             // Clear the series if no data for this interval
             if (prevData) {
               series.setData([])
-              lastIntervalDataRef.current[interval] = null
+              lastStrengthIntervalsRef.current[interval] = null
             }
             return
           }
@@ -392,7 +398,7 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
           )
 
           if (updated) {
-            lastIntervalDataRef.current[interval] = currentData
+            lastStrengthIntervalsRef.current[interval] = currentData
           }
 
           // Control visibility based on:
@@ -409,17 +415,17 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
           })
         })
       } catch (error) {
-        console.warn('Failed to update interval data:', error)
+        console.warn('Failed to update strength intervals data:', error)
       }
     }, [
-      intervalStrengthData,
+      strengthIntervals,
       showIntervalLines,
       showStrengthLine,
       selectedIntervals,
       name,
     ])
 
-    // Update ticker series data (for individual ticker price lines)
+    // Update price ticker series data (for individual ticker price lines)
     // ALWAYS update data, control visibility separately via series.applyOptions
     useEffect(() => {
       if (!hasInitialized.current || !chartRef.current) return
@@ -429,31 +435,31 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
 
         // Create series for new tickers that don't have one yet
         tickers.forEach((ticker) => {
-          if (!tickerSeriesRef.current[ticker]) {
+          if (!priceTickerSeriesRef.current[ticker]) {
             const tickerSeries = chart.addSeries(LineSeries, {
               ...getLineSeriesConfig(),
               lineWidth: 1,
               color: COLORS.price_i,
-              priceScaleId: 'right', // Use same scale as aggregated price
+              priceScaleId: 'right', // Use same scale as price average
               visible: showTickerLines, // Set initial visibility
             })
-            tickerSeriesRef.current[ticker] = tickerSeries
+            priceTickerSeriesRef.current[ticker] = tickerSeries
           }
         })
 
         // Update each ticker series with its data
         tickers.forEach((ticker) => {
-          const series = tickerSeriesRef.current[ticker]
+          const series = priceTickerSeriesRef.current[ticker]
           if (!series) return
 
-          const data = tickerPriceData?.[ticker]
-          const prevData = lastTickerDataRef.current[ticker]
+          const data = priceTickers?.[ticker]
+          const prevData = lastPriceTickersRef.current[ticker]
 
           if (!data) {
             // Clear the series if no data for this ticker
             if (prevData) {
               series.setData([])
-              lastTickerDataRef.current[ticker] = null
+              lastPriceTickersRef.current[ticker] = null
             }
             return
           }
@@ -472,7 +478,7 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
           )
 
           if (updated) {
-            lastTickerDataRef.current[ticker] = currentData
+            lastPriceTickersRef.current[ticker] = currentData
           }
 
           // Control visibility based on showTickerLines
@@ -482,19 +488,19 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
         })
 
         // Clear data for tickers that are no longer selected
-        Object.keys(tickerSeriesRef.current).forEach((ticker) => {
+        Object.keys(priceTickerSeriesRef.current).forEach((ticker) => {
           if (!tickers.includes(ticker)) {
-            const series = tickerSeriesRef.current[ticker]
-            if (series && lastTickerDataRef.current[ticker]) {
+            const series = priceTickerSeriesRef.current[ticker]
+            if (series && lastPriceTickersRef.current[ticker]) {
               series.setData([])
-              lastTickerDataRef.current[ticker] = null
+              lastPriceTickersRef.current[ticker] = null
             }
           }
         })
       } catch (error) {
-        console.warn('Failed to update ticker data:', error)
+        console.warn('Failed to update price tickers data:', error)
       }
-    }, [tickerPriceData, showTickerLines, tickers, name])
+    }, [priceTickers, showTickerLines, tickers, name])
 
     // Update chart dimensions when they change
     useEffect(() => {
@@ -518,7 +524,10 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
 
       // Check that we have data in the series before setting visible range
       // setVisibleRange will fail with "Value is null" if series is empty
-      if (!lastDataRef.current || lastDataRef.current.length === 0) {
+      if (
+        !lastStrengthAverageRef.current ||
+        lastStrengthAverageRef.current.length === 0
+      ) {
         // No data yet - don't try to set range
         return
       }
@@ -530,26 +539,26 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
       }
     }, [timeRange])
 
-    // Toggle visibility of aggregated strength line
+    // Toggle visibility of strength average line
     useEffect(() => {
-      if (!strengthSeriesRef.current || !hasInitialized.current) return
+      if (!strengthAverageSeriesRef.current || !hasInitialized.current) return
 
-      strengthSeriesRef.current.applyOptions({
+      strengthAverageSeriesRef.current.applyOptions({
         visible: showStrengthLine,
         lineWidth: 2, // Always prominent when visible (it's the main aggregate line)
       })
     }, [showStrengthLine])
 
-    // Toggle visibility of aggregated price line
+    // Toggle visibility of price average line
     useEffect(() => {
-      if (!priceSeriesRef.current || !hasInitialized.current) return
+      if (!priceAverageSeriesRef.current || !hasInitialized.current) return
 
-      priceSeriesRef.current.applyOptions({
+      priceAverageSeriesRef.current.applyOptions({
         visible: showPriceLine,
       })
     }, [showPriceLine])
 
-    const hasData = strengthData !== null
+    const hasData = strengthAverage !== null
 
     return (
       <div

--- a/apps/strength/charts/components/Chart.tsx
+++ b/apps/strength/charts/components/Chart.tsx
@@ -38,6 +38,7 @@ interface ChartProps {
   priceAverageData?: LineData[] | null
   strengthIntervalsData?: StrengthIntervalsData
   priceTickersData?: PriceTickersData
+  strengthIndicatorData?: LineData[] | null
   tickers?: string[]
   width: number
   height: number
@@ -64,6 +65,7 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
       priceAverageData: priceAverage,
       strengthIntervalsData: strengthIntervals,
       priceTickersData: priceTickers,
+      strengthIndicatorData: strengthIndicator,
       tickers = [],
       width,
       height,
@@ -77,6 +79,7 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
       showIntervalLines,
       showPriceLine,
       showTickerLines,
+      showIndicatorLine,
       hoursBack,
       interval: selectedIntervals, // Which intervals are selected (for visibility)
     } = useChartControlsStore()
@@ -89,6 +92,7 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
       Record<string, ISeriesApi<'Line'>>
     >({})
     const priceTickerSeriesRef = useRef<Record<string, ISeriesApi<'Line'>>>({})
+    const strengthIndicatorSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
     const zeroLineSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
     const plus100LineSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
     const minus100LineSeriesRef = useRef<ISeriesApi<'Line'> | null>(null)
@@ -97,6 +101,7 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
     const lastPriceAverageRef = useRef<LineData[] | null>(null)
     const lastStrengthIntervalsRef = useRef<StrengthIntervalsData>({})
     const lastPriceTickersRef = useRef<PriceTickersData>({})
+    const lastStrengthIndicatorRef = useRef<LineData[] | null>(null)
 
     // Use extracted hooks
     const { createTimeMarkers, markersInitialized } = useTimeMarkers()
@@ -176,6 +181,15 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
       })
       strengthAverageSeriesRef.current = strengthAverageSeries
 
+      // Strength indicator (moving average) - uses 'left' scale
+      const strengthIndicatorSeries = chart.addSeries(LineSeries, {
+        ...getLineSeriesConfig(),
+        lineWidth: 2,
+        color: COLORS.indicator,
+        priceScaleId: 'left',
+      })
+      strengthIndicatorSeriesRef.current = strengthIndicatorSeries
+
       // Strength interval series - uses 'left' scale to compare with strength average
       // These are created once and data is set/updated later
       STRENGTH_INTERVALS.forEach((interval) => {
@@ -198,6 +212,9 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
       if (priceAverage && priceAverageSeriesRef.current) {
         priceAverageSeriesRef.current.setData(priceAverage)
       }
+      if (strengthIndicator && strengthIndicatorSeriesRef.current) {
+        strengthIndicatorSeriesRef.current.setData(strengthIndicator)
+      }
 
       // Set initial strength intervals data if available
       if (strengthIntervals) {
@@ -218,6 +235,7 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
         chartRef.current = null
         strengthAverageSeriesRef.current = null
         priceAverageSeriesRef.current = null
+        strengthIndicatorSeriesRef.current = null
         zeroLineSeriesRef.current = null
         plus100LineSeriesRef.current = null
         minus100LineSeriesRef.current = null
@@ -361,6 +379,39 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
         console.warn('Failed to update price average data:', error)
       }
     }, [priceAverage, name])
+
+    // Update strength indicator series data
+    useEffect(() => {
+      if (
+        !strengthIndicatorSeriesRef.current ||
+        !strengthIndicator ||
+        !hasInitialized.current
+      )
+        return
+
+      try {
+        const prevData = lastStrengthIndicatorRef.current
+
+        // Apply forward-fill to ensure time range boundaries exist
+        const currentData = prepareDataWithRequiredTimestamps(
+          strengthIndicator,
+          TIME_RANGE_HIGHLIGHTS
+        )
+
+        // Use efficient update strategy
+        const updated = updateSeriesEfficiently(
+          strengthIndicatorSeriesRef.current,
+          currentData,
+          prevData
+        )
+
+        if (updated) {
+          lastStrengthIndicatorRef.current = currentData
+        }
+      } catch (error) {
+        console.warn('Failed to update strength indicator data:', error)
+      }
+    }, [strengthIndicator, name])
 
     // Update strength interval series data
     // ALWAYS update data, control visibility separately via series.applyOptions
@@ -557,6 +608,15 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
         visible: showPriceLine,
       })
     }, [showPriceLine])
+
+    // Toggle visibility of strength indicator line
+    useEffect(() => {
+      if (!strengthIndicatorSeriesRef.current || !hasInitialized.current) return
+
+      strengthIndicatorSeriesRef.current.applyOptions({
+        visible: showIndicatorLine,
+      })
+    }, [showIndicatorLine])
 
     const hasData = strengthAverage !== null
 

--- a/apps/strength/charts/components/controls/InlineControls.tsx
+++ b/apps/strength/charts/components/controls/InlineControls.tsx
@@ -15,6 +15,8 @@ export default function InlineControls({
   drawerCalendarOpen: () => void
 }) {
   const {
+    showIndicatorLine,
+    setShowIndicatorLine,
     showStrengthLine,
     setShowStrengthLine,
     showIntervalLines,
@@ -39,11 +41,28 @@ export default function InlineControls({
           </span>
         </div>
       </div>
+      {/* Indicator line toggle */}
+      <div className="flex">
+        <button
+          onClick={() => setShowIndicatorLine(!showIndicatorLine)}
+          className={`px-1.5 py-0.5 text-xs rounded-l transition-colors border-l border-t border-b`}
+          style={{
+            borderColor: showIndicatorLine ? COLORS.indicator : 'transparent',
+            backgroundColor: showIndicatorLine
+              ? COLORS.indicator + '20'
+              : 'transparent',
+            color: COLORS.indicator,
+          }}
+          title="Show/hide aggregate indicator line"
+        >
+          I
+        </button>
+      </div>
       {/* Strength line toggles */}
       <div className="flex">
         <button
           onClick={() => setShowStrengthLine(!showStrengthLine)}
-          className={`px-1.5 py-0.5 text-xs rounded-l transition-colors border-l border-t border-b`}
+          className={`px-1.5 py-0.5 text-xs transition-colors border-l border-t border-b`}
           style={{
             borderColor: showStrengthLine ? COLORS.strength : 'transparent',
             backgroundColor: showStrengthLine

--- a/apps/strength/charts/components/controls/IntervalControl.tsx
+++ b/apps/strength/charts/components/controls/IntervalControl.tsx
@@ -1,7 +1,7 @@
 import { MultiSelect } from '@mantine/core'
 import {
   useChartControlsStore,
-  strengthIntervals,
+  strengthIntervalsAll,
 } from '../../state/useChartControlsStore'
 import React from 'react'
 
@@ -21,7 +21,7 @@ export default function IntervalControl({ showLabel = true }: Props) {
     <MultiSelect
       label={showLabel ? 'Interval' : undefined}
       value={interval}
-      data={strengthIntervals}
+      data={strengthIntervalsAll}
       onChange={setInterval}
       styles={{
         pill: {

--- a/apps/strength/charts/constants.ts
+++ b/apps/strength/charts/constants.ts
@@ -24,6 +24,9 @@ export const COLORS = {
   strength_ii: 'hsla(35 100% 50% / 0.44)', // Orange transparent
   strength_iii: 'hsla(35 100% 50% / 0.22)', // Orange transparent
 
+  // Indicator (moving average) - distinct color for visibility
+  indicator: 'hsl(300 85% 60%)', // Magenta/pink for contrast
+
   // price_i: 'hsla(275 85% 70% / 0.5)', // Purple transparent
   price_i: 'hsla(233 100% 75% / 0.67)', // Blue transparent
   light_i: '#CDCCC835',

--- a/apps/strength/charts/constants.ts
+++ b/apps/strength/charts/constants.ts
@@ -12,20 +12,21 @@ export const SCROLL_PAUSE_RESUME_MS = 300000 // 30 seconds
 export const COLORS = {
   red: 'hsl(0 75.53% 53.53%)',
   green: 'hsl(120 70.8% 44.31%)',
+  purple: 'hsl(275 85% 70%)', // Purple
   dark: '#777777',
-  // Main aggregated lines
+  // Indicator
+  indicator: 'hsl(120 70.8% 44.31%)',
+  // Strength
   strength: 'hsl(35 100% 50%)', // Orange
-  // price: 'hsl(275 85% 70%)', // Purple
+  // Price
   price: 'hsl(233 100% 75%)', // Blue
+  // Etc
   light: '#B5B5B566', // Light gray
 
   // Individual lines (lighter versions)
   strength_i: 'hsla(35 100% 50% / 0.55)', // Orange transparent
   strength_ii: 'hsla(35 100% 50% / 0.44)', // Orange transparent
   strength_iii: 'hsla(35 100% 50% / 0.22)', // Orange transparent
-
-  // Indicator (moving average) - distinct color for visibility
-  indicator: 'hsl(300 85% 60%)', // Magenta/pink for contrast
 
   // price_i: 'hsla(275 85% 70% / 0.5)', // Purple transparent
   price_i: 'hsla(233 100% 75% / 0.67)', // Blue transparent

--- a/apps/strength/charts/lib/aggregation/aggregatePriceData.ts
+++ b/apps/strength/charts/lib/aggregation/aggregatePriceData.ts
@@ -6,7 +6,7 @@ import {
   generateFutureTimestamps,
   extendDataIntoFuture,
 } from './aggregateDataUtils'
-import { TickerPriceData } from '../../state/useChartControlsStore'
+import { PriceTickersData } from '../../state/useChartControlsStore'
 
 // ============================================================================
 // TYPES
@@ -242,7 +242,7 @@ export const aggregatePriceByTicker = (
   allRawData: (StrengthRowGet[] | null)[],
   tickers: string[],
   allMarketData?: (StrengthRowGet[] | null)[]
-): TickerPriceData => {
+): PriceTickersData => {
   const context = processTickersForNormalization(
     allRawData,
     tickers,
@@ -256,7 +256,7 @@ export const aggregatePriceByTicker = (
     processedTickers,
     sortedTimestamps,
   } = context
-  const result: TickerPriceData = {}
+  const result: PriceTickersData = {}
 
   // Process each ticker using the shared normalization context
   processedTickers.forEach((ticker) => {

--- a/apps/strength/charts/lib/aggregation/aggregateStrengthData.ts
+++ b/apps/strength/charts/lib/aggregation/aggregateStrengthData.ts
@@ -6,7 +6,7 @@ import {
   extendDataIntoFuture,
 } from './aggregateDataUtils'
 import {
-  strengthIntervals as STRENGTH_INTERVALS,
+  strengthIntervalsAll as STRENGTH_INTERVALS,
   StrengthIntervalsData,
 } from '../../state/useChartControlsStore'
 

--- a/apps/strength/charts/lib/aggregation/aggregateStrengthData.ts
+++ b/apps/strength/charts/lib/aggregation/aggregateStrengthData.ts
@@ -6,8 +6,8 @@ import {
   extendDataIntoFuture,
 } from './aggregateDataUtils'
 import {
-  strengthIntervals,
-  IntervalStrengthData,
+  strengthIntervals as STRENGTH_INTERVALS,
+  StrengthIntervalsData,
 } from '../../state/useChartControlsStore'
 
 /**
@@ -86,7 +86,7 @@ export const aggregateStrengthByInterval = (
   allRawData: (StrengthRowGet[] | null)[],
   selectedIntervals: string[],
   allMarketData?: (StrengthRowGet[] | null)[]
-): IntervalStrengthData => {
+): StrengthIntervalsData => {
   // Extract all unique timestamps from ALL market data to ensure consistency
   const dataForTimestamps = allMarketData || allRawData
   const sortedTimestamps = extractGlobalTimestamps(dataForTimestamps)
@@ -95,10 +95,10 @@ export const aggregateStrengthByInterval = (
     return {}
   }
 
-  const result: IntervalStrengthData = {}
+  const result: StrengthIntervalsData = {}
 
   // Process each interval that's selected
-  for (const interval of strengthIntervals) {
+  for (const interval of STRENGTH_INTERVALS) {
     // Only process intervals that are selected
     if (!selectedIntervals.includes(interval)) {
       continue

--- a/apps/strength/charts/lib/computeIndicator.ts
+++ b/apps/strength/charts/lib/computeIndicator.ts
@@ -1,0 +1,49 @@
+import { LineData, Time } from 'lightweight-charts'
+
+/**
+ * Compute a Simple Moving Average (SMA) from LineData
+ *
+ * @param data - The source data (e.g., strengthAverage)
+ * @param period - Number of data points to average over
+ * @returns Moving average data with same time points
+ */
+export function computeMovingAverage(
+  data: LineData<Time>[] | null,
+  period: number
+): LineData<Time>[] | null {
+  if (!data || data.length === 0) return null
+
+  const result: LineData<Time>[] = []
+
+  for (let i = 0; i < data.length; i++) {
+    // Calculate SMA for this point
+    const start = Math.max(0, i - period + 1)
+    const window = data.slice(start, i + 1)
+    const sum = window.reduce((acc, d) => acc + d.value, 0)
+    const avg = sum / window.length
+
+    result.push({
+      time: data[i]!.time,
+      value: avg,
+    })
+  }
+
+  return result
+}
+
+/**
+ * Compute the strength indicator from strength average data
+ *
+ * This is the main entry point for indicator computation.
+ * Expand this function to add more sophisticated indicator logic.
+ *
+ * @param strengthAverage - The aggregated strength average data
+ * @returns The computed indicator series
+ */
+export function computeStrengthIndicator(
+  strengthAverage: LineData<Time>[] | null
+): LineData<Time>[] | null {
+  // Currently uses a 20-period simple moving average
+  // TODO: Expand with more sophisticated indicator logic
+  return computeMovingAverage(strengthAverage, 20)
+}

--- a/apps/strength/charts/lib/computeStrengthIndicator.ts
+++ b/apps/strength/charts/lib/computeStrengthIndicator.ts
@@ -1,13 +1,30 @@
 import { LineData, Time } from 'lightweight-charts'
 
 /**
+ * Compute the strength indicator from strength average data
+ *
+ * This is the main entry point for indicator computation.
+ * Expand this function to add more sophisticated indicator logic.
+ *
+ * @param strengthAverage - The aggregated strength average data
+ * @returns The computed indicator series
+ */
+export function computeStrengthIndicator(
+  strengthAverage: LineData<Time>[] | null
+): LineData<Time>[] | null {
+  // Currently uses a 20-period simple moving average
+  // TODO: Expand with more sophisticated indicator logic
+  return movingAverage(strengthAverage, 20)
+}
+
+/**
  * Compute a Simple Moving Average (SMA) from LineData
  *
  * @param data - The source data (e.g., strengthAverage)
  * @param period - Number of data points to average over
  * @returns Moving average data with same time points
  */
-export function computeMovingAverage(
+function movingAverage(
   data: LineData<Time>[] | null,
   period: number
 ): LineData<Time>[] | null {
@@ -29,21 +46,4 @@ export function computeMovingAverage(
   }
 
   return result
-}
-
-/**
- * Compute the strength indicator from strength average data
- *
- * This is the main entry point for indicator computation.
- * Expand this function to add more sophisticated indicator logic.
- *
- * @param strengthAverage - The aggregated strength average data
- * @returns The computed indicator series
- */
-export function computeStrengthIndicator(
-  strengthAverage: LineData<Time>[] | null
-): LineData<Time>[] | null {
-  // Currently uses a 20-period simple moving average
-  // TODO: Expand with more sophisticated indicator logic
-  return computeMovingAverage(strengthAverage, 20)
 }

--- a/apps/strength/charts/lib/data/useRealtimeStrengthData.ts
+++ b/apps/strength/charts/lib/data/useRealtimeStrengthData.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import { StrengthRowGet } from '@lib/common/sql/strength'
 import { FetchStrengthData } from './FetchStrengthData'
 import { FETCH_DATA_HOURS_BACK } from '../../constants'
-import { strengthIntervals } from '../../state/useChartControlsStore'
+import { strengthIntervalsAll } from '../../state/useChartControlsStore'
 
 export interface UseRealtimeStrengthDataOptions {
   tickers: string[]
@@ -131,7 +131,7 @@ export function useRealtimeStrengthData({
     const filled = { ...currentRow }
 
     // Forward-fill each strength interval if null
-    strengthIntervals.forEach((interval) => {
+    strengthIntervalsAll.forEach((interval) => {
       if (filled[interval] === null && historicalRow[interval] !== null) {
         filled[interval] = historicalRow[interval]
       }

--- a/apps/strength/charts/lib/data/useStrengthData.ts
+++ b/apps/strength/charts/lib/data/useStrengthData.ts
@@ -26,7 +26,7 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import { StrengthRowGet } from '@lib/common/sql/strength'
 import { FetchStrengthData } from './FetchStrengthData'
 import { FETCH_DATA_HOURS_BACK } from '../../constants'
-import { strengthIntervals } from '../../state/useChartControlsStore'
+import { strengthIntervalsAll } from '../../state/useChartControlsStore'
 
 export type DataState = 'idle' | 'loading' | 'ready'
 
@@ -61,7 +61,7 @@ function forwardFillRow(
   const filled = { ...currentRow }
 
   // Forward-fill each interval if null
-  strengthIntervals.forEach((interval) => {
+  strengthIntervalsAll.forEach((interval) => {
     if (filled[interval] === null && previousRow[interval] !== null) {
       filled[interval] = previousRow[interval]
     }
@@ -97,7 +97,7 @@ function buildLastKnownValuesRow(
   const compositeRow: StrengthRowGet = { ...lastRow }
 
   // For each interval, search backwards to find the last non-null value
-  for (const interval of strengthIntervals) {
+  for (const interval of strengthIntervalsAll) {
     if (compositeRow[interval] !== null) continue // Already have a value
 
     // Search backwards for a non-null value for this specific interval

--- a/apps/strength/charts/lib/workers/aggregation.worker.ts
+++ b/apps/strength/charts/lib/workers/aggregation.worker.ts
@@ -574,20 +574,20 @@ self.onmessage = (event: MessageEvent<AggregationWorkerRequest>) => {
       throw new Error(`Unknown message type: ${type}`)
     }
 
-    const { rawData, intervals, tickers, strengthIntervals } = payload
+    const { rawData, intervals, tickers, strengthIntervals: strengthIntervals_all } = payload
 
     // Perform all aggregations
     // Average strength uses selected intervals (user controls what goes into average)
-    const strengthData = aggregateStrengthData(rawData, intervals)
-    const priceData = aggregatePriceData(rawData)
+    const strengthAverage = aggregateStrengthData(rawData, intervals)
+    const priceAverage = aggregatePriceData(rawData)
     // Individual interval lines: compute ALL intervals (visibility controlled by UI)
     // This avoids re-aggregation when user changes interval selection
-    const intervalStrengthData = aggregateStrengthByInterval(
+    const strengthIntervals = aggregateStrengthByInterval(
       rawData,
-      strengthIntervals,  // ALL intervals, not just selected
-      strengthIntervals
+      strengthIntervals_all,  // ALL intervals, not just selected
+      strengthIntervals_all
     )
-    const tickerPriceData = aggregatePriceByTicker(rawData, tickers)
+    const priceTickers = aggregatePriceByTicker(rawData, tickers)
 
     const processingTimeMs = performance.now() - startTime
 
@@ -596,10 +596,10 @@ self.onmessage = (event: MessageEvent<AggregationWorkerRequest>) => {
       requestId, // Echo back the request ID
       dataVersion, // Echo back the data version for validation
       payload: {
-        strengthData: strengthData.length > 0 ? strengthData : null,
-        priceData: priceData.length > 0 ? priceData : null,
-        intervalStrengthData,
-        tickerPriceData,
+        strengthAverage: strengthAverage.length > 0 ? strengthAverage : null,
+        priceAverage: priceAverage.length > 0 ? priceAverage : null,
+        strengthIntervals,
+        priceTickers,
         processingTimeMs,
       },
     }

--- a/apps/strength/charts/lib/workers/types.ts
+++ b/apps/strength/charts/lib/workers/types.ts
@@ -55,10 +55,10 @@ export interface AggregationWorkerResponse {
   requestId: number // Echo back the request ID
   dataVersion: number // Echo back the data version
   payload: {
-    strengthData: WorkerLineData[] | null
-    priceData: WorkerLineData[] | null
-    intervalStrengthData: Record<string, WorkerLineData[]>
-    tickerPriceData: Record<string, WorkerLineData[]>
+    strengthAverage: WorkerLineData[] | null
+    priceAverage: WorkerLineData[] | null
+    strengthIntervals: Record<string, WorkerLineData[]>
+    priceTickers: Record<string, WorkerLineData[]>
     processingTimeMs: number
   }
 }

--- a/apps/strength/charts/lib/workers/useAggregationWorker.ts
+++ b/apps/strength/charts/lib/workers/useAggregationWorker.ts
@@ -22,10 +22,10 @@ import type {
 import { strengthIntervals } from '../../state/useChartControlsStore'
 
 export interface AggregationResult {
-  strengthData: LineData<Time>[] | null
-  priceData: LineData<Time>[] | null
-  intervalStrengthData: Record<string, LineData<Time>[]>
-  tickerPriceData: Record<string, LineData<Time>[]>
+  strengthAverage: LineData<Time>[] | null
+  priceAverage: LineData<Time>[] | null
+  strengthIntervals: Record<string, LineData<Time>[]>
+  priceTickers: Record<string, LineData<Time>[]>
 }
 
 /**
@@ -180,12 +180,12 @@ export function useAggregationWorker(
         // Convert WorkerLineData to LineData<Time> for lightweight-charts
         onResultRef.current?.(
           {
-            strengthData: convertToLineData(payload.strengthData),
-            priceData: convertToLineData(payload.priceData),
-            intervalStrengthData: convertRecordToLineData(
-              payload.intervalStrengthData
+            strengthAverage: convertToLineData(payload.strengthAverage),
+            priceAverage: convertToLineData(payload.priceAverage),
+            strengthIntervals: convertRecordToLineData(
+              payload.strengthIntervals
             ),
-            tickerPriceData: convertRecordToLineData(payload.tickerPriceData),
+            priceTickers: convertRecordToLineData(payload.priceTickers),
           },
           payload.processingTimeMs,
           dataVersion

--- a/apps/strength/charts/lib/workers/useAggregationWorker.ts
+++ b/apps/strength/charts/lib/workers/useAggregationWorker.ts
@@ -19,7 +19,7 @@ import type {
   AggregationWorkerResponse,
   WorkerMessage,
 } from './types'
-import { strengthIntervals } from '../../state/useChartControlsStore'
+import { strengthIntervalsAll } from '../../state/useChartControlsStore'
 
 export interface AggregationResult {
   strengthAverage: LineData<Time>[] | null
@@ -103,7 +103,7 @@ function toWorkerRow(row: StrengthRowGet): WorkerStrengthRow {
   }
 
   // Copy all interval values
-  for (const interval of strengthIntervals) {
+  for (const interval of strengthIntervalsAll) {
     result[interval] = row[interval as keyof StrengthRowGet] as number | null
   }
 
@@ -252,7 +252,7 @@ export function useAggregationWorker(
           rawData: serializedData,
           intervals,
           tickers,
-          strengthIntervals: [...strengthIntervals],
+          strengthIntervals: [...strengthIntervalsAll],
         },
       }
 

--- a/apps/strength/charts/state/AGENTS.md
+++ b/apps/strength/charts/state/AGENTS.md
@@ -17,6 +17,7 @@ Zustand store for chart controls with URL query parameter synchronization.
   - `showIntervalLines` - Toggle individual interval strength lines
   - `showPriceLine` - Toggle aggregate price line
   - `showTickerLines` - Toggle individual ticker price lines
-- `aggregatedStrengthData` / `aggregatedPriceData` - Cached aggregated data
+- `strengthAverage` / `priceAverage` - Cached aggregated data
+- `strengthIntervals` / `priceTickers` - Individual interval/ticker line data
 
 State changes automatically update URL, allowing users to bookmark specific chart configurations.

--- a/apps/strength/charts/state/useChartControlsStore.ts
+++ b/apps/strength/charts/state/useChartControlsStore.ts
@@ -7,7 +7,7 @@ import { NEW_INTERVALS } from '@lib/common/sql/strength/constants'
 // ============================================================================
 // CONFIGURATION CONSTANTS
 // ============================================================================
-export const strengthIntervals = NEW_INTERVALS
+export const strengthIntervalsAll = NEW_INTERVALS
 
 /**
  * Filter out intervals that are too noisy or not useful for default display
@@ -184,7 +184,7 @@ const getInitialState = (): State => {
 
   const defaultState: State = {
     hoursBack: hoursBackInitial,
-    interval: getDefaultIntervals(strengthIntervals),
+    interval: getDefaultIntervals(strengthIntervalsAll),
     chartTickers: defaultTickers,
     timeRange: null,
     cursorTime: null,

--- a/apps/strength/charts/state/useChartControlsStore.ts
+++ b/apps/strength/charts/state/useChartControlsStore.ts
@@ -72,13 +72,15 @@ export const tickersByMarket = [
 
 /**
  * Individual interval strength data - keyed by interval string
+ * Each interval (e.g., "30S", "1", "3") has its own line data
  */
-export type IntervalStrengthData = Record<string, LineData[] | null>
+export type StrengthIntervalsData = Record<string, LineData[] | null>
 
 /**
  * Individual ticker price data - keyed by ticker symbol
+ * Each ticker (e.g., "ES1!", "NQ1!") has its own line data
  */
-export type TickerPriceData = Record<string, LineData[] | null>
+export type PriceTickersData = Record<string, LineData[] | null>
 
 /**
  * Store state for chart controls and data management
@@ -98,15 +100,15 @@ type State = {
   timeRange: { from: Time; to: Time } | null
   cursorTime: Time | null
 
-  // Aggregated data for charts
-  aggregatedStrengthData: LineData[] | null
-  aggregatedPriceData: LineData[] | null
+  // Aggregated data for charts (averaged from intervals/tickers)
+  strengthAverage: LineData[] | null
+  priceAverage: LineData[] | null
 
   // Individual interval strength data (one line per interval)
-  intervalStrengthData: IntervalStrengthData
+  strengthIntervals: StrengthIntervalsData
 
   // Individual ticker price data (one line per ticker)
-  tickerPriceData: TickerPriceData
+  priceTickers: PriceTickersData
 
   // Toggle for showing aggregate average strength line (default: true)
   showStrengthLine: boolean
@@ -141,10 +143,10 @@ type Actions = {
   setCursorTime: (time: Time | null) => void
 
   // Data setters
-  setAggregatedStrengthData: (data: LineData[] | null) => void
-  setAggregatedPriceData: (data: LineData[] | null) => void
-  setIntervalStrengthData: (data: IntervalStrengthData) => void
-  setTickerPriceData: (data: TickerPriceData) => void
+  setStrengthAverage: (data: LineData[] | null) => void
+  setPriceAverage: (data: LineData[] | null) => void
+  setStrengthIntervals: (data: StrengthIntervalsData) => void
+  setPriceTickers: (data: PriceTickersData) => void
 
   // Display toggles
   setShowStrengthLine: (show: boolean) => void
@@ -186,10 +188,10 @@ const getInitialState = (): State => {
     chartTickers: defaultTickers,
     timeRange: null,
     cursorTime: null,
-    aggregatedStrengthData: null,
-    aggregatedPriceData: null,
-    intervalStrengthData: {},
-    tickerPriceData: {},
+    strengthAverage: null,
+    priceAverage: null,
+    strengthIntervals: {},
+    priceTickers: {},
     showStrengthLine: false,
     showIntervalLines: true,
     showPriceLine: false,
@@ -262,20 +264,20 @@ export const useChartControlsStore = create<ChartControlsStore>()(
       },
 
       // Data setters
-      setAggregatedStrengthData: (data: LineData[] | null) => {
-        set({ aggregatedStrengthData: data })
+      setStrengthAverage: (data: LineData[] | null) => {
+        set({ strengthAverage: data })
       },
 
-      setAggregatedPriceData: (data: LineData[] | null) => {
-        set({ aggregatedPriceData: data })
+      setPriceAverage: (data: LineData[] | null) => {
+        set({ priceAverage: data })
       },
 
-      setIntervalStrengthData: (data: IntervalStrengthData) => {
-        set({ intervalStrengthData: { ...data } })
+      setStrengthIntervals: (data: StrengthIntervalsData) => {
+        set({ strengthIntervals: { ...data } })
       },
 
-      setTickerPriceData: (data: TickerPriceData) => {
-        set({ tickerPriceData: { ...data } })
+      setPriceTickers: (data: PriceTickersData) => {
+        set({ priceTickers: { ...data } })
       },
 
       // Display toggles

--- a/apps/strength/charts/state/useChartControlsStore.ts
+++ b/apps/strength/charts/state/useChartControlsStore.ts
@@ -110,8 +110,14 @@ type State = {
   // Individual ticker price data (one line per ticker)
   priceTickers: PriceTickersData
 
+  // Strength indicator (moving average of strengthAverage)
+  strengthIndicator: LineData[] | null
+
   // Toggle for showing aggregate average strength line (default: true)
   showStrengthLine: boolean
+
+  // Toggle for showing strength indicator line (default: true)
+  showIndicatorLine: boolean
 
   // Toggle for showing individual interval strength lines (default: false)
   showIntervalLines: boolean
@@ -147,9 +153,11 @@ type Actions = {
   setPriceAverage: (data: LineData[] | null) => void
   setStrengthIntervals: (data: StrengthIntervalsData) => void
   setPriceTickers: (data: PriceTickersData) => void
+  setStrengthIndicator: (data: LineData[] | null) => void
 
   // Display toggles
   setShowStrengthLine: (show: boolean) => void
+  setShowIndicatorLine: (show: boolean) => void
   setShowIntervalLines: (show: boolean) => void
   setShowPriceLine: (show: boolean) => void
   setShowTickerLines: (show: boolean) => void
@@ -192,10 +200,12 @@ const getInitialState = (): State => {
     priceAverage: null,
     strengthIntervals: {},
     priceTickers: {},
+    strengthIndicator: null,
     showStrengthLine: false,
     showIntervalLines: true,
     showPriceLine: false,
     showTickerLines: true,
+    showIndicatorLine: true,
     isHydrated: false,
   }
 
@@ -280,9 +290,17 @@ export const useChartControlsStore = create<ChartControlsStore>()(
         set({ priceTickers: { ...data } })
       },
 
+      setStrengthIndicator: (data: LineData[] | null) => {
+        set({ strengthIndicator: data })
+      },
+
       // Display toggles
       setShowStrengthLine: (show: boolean) => {
         set({ showStrengthLine: show })
+      },
+
+      setShowIndicatorLine: (show: boolean) => {
+        set({ showIndicatorLine: show })
       },
 
       setShowIntervalLines: (show: boolean) => {

--- a/apps/strength/charts/state/useChartControlsStore.ts
+++ b/apps/strength/charts/state/useChartControlsStore.ts
@@ -205,7 +205,7 @@ const getInitialState = (): State => {
     showIntervalLines: true,
     showPriceLine: false,
     showTickerLines: true,
-    showIndicatorLine: true,
+    showIndicatorLine: false,
     isHydrated: false,
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a new aggregate indicator and aligns naming across charts, worker, and store for clarity and consistency.
> 
> - Adds `computeStrengthIndicator` (20-period SMA) and renders an indicator line with a new `showIndicatorLine` toggle; extends `COLORS` with `indicator`
> - Refactors data model: `strength`→`strengthAverage`, `price`→`priceAverage`, `intervalStrength`→`strengthIntervals`, `tickerPrice`→`priceTickers`; cache keys, local state, and store actions/selectors updated
> - Updates Web Worker types/logic and hook to emit/consume new fields (`strengthAverage`, `priceAverage`, `strengthIntervals`, `priceTickers`) and pass `strengthIntervalsAll`
> - Chart component adapts props/series to new names, adds indicator series visibility control, and maintains reference lines and forward-fill/time-range behavior
> - Store (Zustand) schema extended with `strengthIndicator` and `showIndicatorLine`; interval constant renamed to `strengthIntervalsAll`; controls UI adds Indicator button
> - Data hooks (`useStrengthData`, realtime) migrated to `strengthIntervalsAll` and retain forward-fill logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56109d6323da4802eca148a04f7ccea7f1ffb644. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->