### PR TITLE
Configure agent permissions and optional phases

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,10 +10,10 @@ All agents are defined in `.claude/agents/`:
 
 1. orchestrator.md - Opus 4.5, coordinates all phases sequentially
 2. codebase-explorer.md - Sonnet, reads and understands the codebase
-3. web-researcher.md - Sonnet, performs deep web research
+3. web-researcher.md - Sonnet, performs deep web research **(optional)**
 4. implementer.md - Sonnet, implements the feature/fix
 5. refactorer.md - Sonnet, improves code quality
-6. test-writer.md - Sonnet, writes unit tests
+6. test-writer.md - Sonnet, writes unit tests **(optional)**
 7. reviewer-documenter.md - Sonnet, reviews and documents
 
 ### When to Use This Workflow
@@ -39,6 +39,9 @@ The orchestrator runs each phase **synchronously and sequentially**:
 2. Orchestrator evaluates output before proceeding
 3. Orchestrator may ask user for clarification at any checkpoint
 4. No parallel execution - strict phase ordering
+5. Orchestrator decides which phases to run based on the task
+
+**Optional phases**: Web research and test writing are optional. The orchestrator should skip them if they're not needed for the specific task.
 
 **Context passing**: Subagents have isolated context. They cannot see each other's outputs. The orchestrator must explicitly pass relevant information from previous phases to each subagent.
 

--- a/.claude/agents/codebase-explorer.md
+++ b/.claude/agents/codebase-explorer.md
@@ -4,12 +4,6 @@ description: |
   Phase 1: Explores codebase to understand structure, find affected files,
   read TypeScript types, check AGENTS.md docs, identify knowledge gaps.
 model: sonnet
-allowed_tools:
-  - Read
-  - Glob
-  - Grep
-  - LS
-  - SemanticSearch
 ---
 
 # Codebase Explorer

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -4,14 +4,6 @@ description: |
   Phase 3: Implements the feature/bug/refactor using context from exploration and research.
   Runs build/tests, fixes errors. Considers existing tests. Does NOT write new tests.
 model: sonnet
-allowed_tools:
-  - Read
-  - Write
-  - StrReplace
-  - Glob
-  - Grep
-  - Shell
-  - LS
 ---
 
 # Implementer

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -1,15 +1,15 @@
 ---
 name: orchestrator
 description: |
-  Master orchestrator for multi-agent development workflow. Coordinates 6 subagents 
-  in sequence: explore → research → implement → refactor → test → review.
+  Master orchestrator for multi-agent development workflow. Coordinates subagents
+  in sequence: explore → research (optional) → implement → refactor → test (optional) → review.
   Use for any non-trivial task touching multiple files.
 model: opus
 ---
 
 # Orchestrator
 
-You coordinate a 6-phase development workflow. You are responsible for:
+You coordinate a multi-phase development workflow. You are responsible for:
 - Understanding requirements and deliverables
 - Ensuring scope is clear before proceeding
 - Calling each subagent in sequence with appropriate context
@@ -28,6 +28,8 @@ You coordinate a 6-phase development workflow. You are responsible for:
 
 Execute phases **synchronously in order**. Each subagent has isolated context - they cannot see previous phases. You must explicitly pass the required context to each one.
 
+**Note**: Not all phases are required for every task. Phase 2 (Web Research) and Phase 5 (Test Writing) are optional and should be skipped if not needed.
+
 ### Phase 1: Codebase Exploration
 
 Use the `codebase-explorer` subagent. Pass it:
@@ -39,9 +41,14 @@ Use the `codebase-explorer` subagent. Pass it:
 
 **Evaluate**: Do I understand the codebase? Are affected files identified? What gaps need research?
 
-### Phase 2: Web Research
+### Phase 2: Web Research (Optional)
 
-Use the `web-researcher` subagent. Pass it:
+**Skip this phase if:**
+- No knowledge gaps identified in Phase 1
+- All libraries/APIs are already familiar
+- Implementation is straightforward
+
+**If needed**, use the `web-researcher` subagent. Pass it:
 - The task being implemented
 - Knowledge gaps identified in Phase 1
 - Specific libraries, APIs, or topics to research
@@ -74,9 +81,15 @@ Use the `refactorer` subagent. Pass it:
 
 **Evaluate**: Was code improved? Did build/tests still pass?
 
-### Phase 5: Test Writing
+### Phase 5: Test Writing (Optional)
 
-Use the `test-writer` subagent. Pass it:
+**Skip this phase if:**
+- No new testable functionality was added
+- Changes only affect existing tested code
+- Changes are purely refactoring with existing test coverage
+- Task is documentation-only or configuration-only
+
+**If needed**, use the `test-writer` subagent. Pass it:
 - What new functionality was added
 - Which files contain the new code
 - Key behaviors to test

--- a/.claude/agents/refactorer.md
+++ b/.claude/agents/refactorer.md
@@ -4,14 +4,6 @@ description: |
   Phase 4: Reviews implementation for code quality. Refactors if warranted.
   Runs build/tests after changes. May decide no refactoring needed.
 model: sonnet
-allowed_tools:
-  - Read
-  - Write
-  - StrReplace
-  - Glob
-  - Grep
-  - Shell
-  - LS
 ---
 
 # Refactorer

--- a/.claude/agents/reviewer-documenter.md
+++ b/.claude/agents/reviewer-documenter.md
@@ -4,13 +4,6 @@ description: |
   Phase 6: Final review of all changes. Checks for misunderstandings.
   Creates documentation in app's docs folder. Flags concerns for user.
 model: sonnet
-allowed_tools:
-  - Read
-  - Write
-  - StrReplace
-  - Glob
-  - Grep
-  - LS
 ---
 
 # Reviewer & Documenter

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -4,14 +4,6 @@ description: |
   Phase 5: Writes focused unit tests for new functionality.
   Covers base cases, not 100% coverage. Runs build/tests.
 model: sonnet
-allowed_tools:
-  - Read
-  - Write
-  - StrReplace
-  - Glob
-  - Grep
-  - Shell
-  - LS
 ---
 
 # Test Writer

--- a/.claude/agents/web-researcher.md
+++ b/.claude/agents/web-researcher.md
@@ -4,10 +4,6 @@ description: |
   Phase 2: Deep web research on libraries, APIs, usage patterns, TypeScript types,
   troubleshooting. Fills knowledge gaps from codebase exploration.
 model: sonnet
-allowed_tools:
-  - WebSearch
-  - WebFetch
-  - Read
 ---
 
 # Web Researcher


### PR DESCRIPTION
- Remove allowed_tools restrictions from all agents to grant unlimited permissions
- Make web-researcher and test-writer phases optional in orchestrator
- Update CLAUDE.md to reflect flexible workflow with optional phases
- Orchestrator now decides which phases to run based on task requirements

https://claude.ai/code/session_01R22tAfyKESmzLbdgUffLhe