### PR TITLE
strength: convert charts to dark theme

### DIFF
--- a/apps/strength/app/global.scss
+++ b/apps/strength/app/global.scss
@@ -11,7 +11,8 @@ body {
     width: 200%;
     height: 200%;
   }
-  --mantine-color-text: #000000b9;
+  --mantine-color-text: #C3BCDB;
+  background-color: #1a1a2e;
 }
 .scale2x {
   @media (pointer: fine) {

--- a/apps/strength/app/stream/page.tsx
+++ b/apps/strength/app/stream/page.tsx
@@ -9,7 +9,7 @@ const StreamChartWrapper = dynamic(
 
 export default function Page() {
   return (
-    <ThemeWrapper colorScheme="light">
+    <ThemeWrapper colorScheme="dark">
       <StreamChartWrapper />
     </ThemeWrapper>
   )

--- a/apps/strength/app/tradingview/page.tsx
+++ b/apps/strength/app/tradingview/page.tsx
@@ -3,7 +3,7 @@ import { ThemeWrapper } from '../../components/ThemeWrapper'
 
 export default function Page() {
   return (
-    <ThemeWrapper colorScheme="light">
+    <ThemeWrapper colorScheme="dark">
       <SyncedChartsWrapper />
     </ThemeWrapper>
   )

--- a/apps/strength/stream/Chart.tsx
+++ b/apps/strength/stream/Chart.tsx
@@ -20,13 +20,15 @@ const INITIAL_CANDLES = 5000
 const POLL_INTERVAL_MS = 10_000
 const RECENT_CANDLES = 22
 
-// Color palette
+// Color palette - Dark theme
 const COLORS = {
   price: 'hsl(233 100% 75%)', // Blue
   cvd: 'hsl(120 100% 45%)', // Bright green
   rsi: 'hsl(30 100% 50%)', // Orange
-  background: '#ffffff',
-  gridLine: '#CDCCC835',
+  background: '#1a1a2e',
+  text: '#C3BCDB',
+  gridLine: '#333344',
+  crosshair: '#71649C',
 }
 
 // RSI period
@@ -290,7 +292,7 @@ export function Chart({ width, height }: ChartProps) {
       height,
       layout: {
         background: { color: COLORS.background },
-        textColor: '#333',
+        textColor: COLORS.text,
         attributionLogo: false,
       },
       grid: {
@@ -314,13 +316,13 @@ export function Chart({ width, height }: ChartProps) {
         mode: 0,
         vertLine: {
           visible: true,
-          color: '#758391',
+          color: COLORS.crosshair,
           width: 1,
           style: 0,
         },
         horzLine: {
           visible: true,
-          color: '#758391',
+          color: COLORS.crosshair,
           width: 1,
           style: 0,
         },
@@ -458,7 +460,7 @@ export function Chart({ width, height }: ChartProps) {
             alignItems: 'center',
             justifyContent: 'center',
             height: height + 'px',
-            color: 'red',
+            color: '#ff6b6b',
             background: COLORS.background,
           }}
         >
@@ -496,6 +498,7 @@ export function Chart({ width, height }: ChartProps) {
             alignItems: 'center',
             justifyContent: 'center',
             background: COLORS.background,
+            color: COLORS.text,
             zIndex: 10,
           }}
         >

--- a/apps/strength/tradingview/constants.ts
+++ b/apps/strength/tradingview/constants.ts
@@ -13,13 +13,19 @@ export const SCROLL_PAUSE_RESUME_MS = 300000 // 30 seconds
 
 export const SHOW_100_LINES = false
 
-// Color palette
+// Color palette - Dark theme
 export const COLORS = {
+  // Chart background and layout
+  background: '#1a1a2e',
+  text: '#C3BCDB',
+  gridLine: '#333344',
+  crosshair: '#71649C',
+  // Series colors
   red: 'hsl(0 75.53% 53.53%)',
   green: 'hsl(120 70.8% 44.31%)',
   purple: 'hsl(275 85% 70%)', // Purple
-  dark: '#777777',
-  neutral: '#999999',
+  dark: '#555566',
+  neutral: '#888899',
   // Indicator
   indicator: 'hsl(120 70.8% 44.31%)',
   // Strength
@@ -27,7 +33,7 @@ export const COLORS = {
   // Price
   price: 'hsl(233 100% 75%)', // Blue
   // Etc
-  light: '#B5B5B566', // Light gray
+  light: '#55556666', // Light gray (for dark theme)
 
   // Individual lines (lighter versions)
   strength_i: 'hsla(35 100% 50% / 0.55)', // Orange transparent
@@ -36,7 +42,7 @@ export const COLORS = {
 
   // price_i: 'hsla(275 85% 70% / 0.5)', // Purple transparent
   price_i: 'hsla(233 100% 75% / 0.67)', // Blue transparent
-  light_i: '#CDCCC835',
+  light_i: '#33334455',
 }
 
 // Time markers - vertical lines on the chart

--- a/apps/strength/tradingview/lib/chartConfig.ts
+++ b/apps/strength/tradingview/lib/chartConfig.ts
@@ -29,13 +29,13 @@ export const getChartConfig = (height: number): DeepPartial<ChartOptions> => ({
     timeFormatter,
   },
   layout: {
-    background: { color: '#ffffff' },
-    textColor: '#333',
+    background: { color: COLORS.background },
+    textColor: COLORS.text,
     attributionLogo: false, // Hide TradingView logo
   },
   grid: {
     vertLines: { visible: false }, // Hide vertical grid lines to reduce clutter
-    horzLines: { color: COLORS.light_i },
+    horzLines: { color: COLORS.gridLine },
   },
   // Y-Axis - Enable both left and right scales for dual series
   rightPriceScale: {
@@ -57,13 +57,13 @@ export const getChartConfig = (height: number): DeepPartial<ChartOptions> => ({
     mode: 0, // Normal mode: we'll set Y explicitly via setCrosshairPosition
     vertLine: {
       visible: true,
-      color: '#758391',
+      color: COLORS.crosshair,
       width: 1,
       style: 0, // Solid line
     },
     horzLine: {
       visible: true,
-      color: '#758391',
+      color: COLORS.crosshair,
       width: 1,
       style: 0, // Solid line
     },


### PR DESCRIPTION
Use dark background (#1a1a2e), light text (#C3BCDB), and matching grid/crosshair
colors for lightweight-charts. Updates both /tradingview and /stream pages.