### PR TITLE
Stream chart right margin

### DIFF
--- a/apps/strength/app/global.scss
+++ b/apps/strength/app/global.scss
@@ -10,6 +10,7 @@ body {
     transform-origin: top left;
     width: 200%;
     height: 200%;
+    overflow: hidden; // Prevent scrollbars from creating gaps on full-screen charts
   }
   --mantine-color-text: #000000b9;
 }

--- a/apps/strength/stream/Chart.tsx
+++ b/apps/strength/stream/Chart.tsx
@@ -300,6 +300,7 @@ export function Chart({ width, height }: ChartProps) {
       rightPriceScale: {
         visible: true,
         minimumWidth: 80,
+        borderVisible: false, // Remove border between price scale and chart area
       },
       leftPriceScale: {
         visible: false,
@@ -309,6 +310,7 @@ export function Chart({ width, height }: ChartProps) {
         timeVisible: true,
         secondsVisible: false,
         tickMarkFormatter: timeFormatter,
+        borderVisible: false, // Remove time scale border
       },
       crosshair: {
         mode: 0,

--- a/apps/strength/stream/Chart.tsx
+++ b/apps/strength/stream/Chart.tsx
@@ -29,6 +29,12 @@ const COLORS = {
   gridLine: '#CDCCC835',
 }
 
+// Extra width to extend chart past screen edge, pushing price scale's internal padding off-screen
+// This makes the price numbers appear flush against the right edge
+// Value is in scaled pixels (at 2x scale factor, 20px = 10px visual on screen)
+// The price scale has ~5-8px internal padding, so 10px visual should fully cover it
+const PRICE_SCALE_RIGHT_OFFSET = 20
+
 // RSI period
 const RSI_PERIOD = 14
 
@@ -285,8 +291,12 @@ export function Chart({ width, height }: ChartProps) {
   useEffect(() => {
     if (!containerRef.current || hasInitialized.current) return
 
+    // Extend chart width past screen edge to push price scale's internal padding off-screen
+    // This makes the price numbers appear flush against the right edge
+    const chartWidth = width + PRICE_SCALE_RIGHT_OFFSET
+
     const chart = createChart(containerRef.current, {
-      width,
+      width: chartWidth,
       height,
       layout: {
         background: { color: COLORS.background },
@@ -443,7 +453,7 @@ export function Chart({ width, height }: ChartProps) {
   // Update chart dimensions
   useEffect(() => {
     if (!chartRef.current || !hasInitialized.current) return
-    chartRef.current.applyOptions({ width, height })
+    chartRef.current.applyOptions({ width: width + PRICE_SCALE_RIGHT_OFFSET, height })
   }, [width, height])
 
   if (error) {
@@ -473,12 +483,14 @@ export function Chart({ width, height }: ChartProps) {
   // Match tradingview/components/Chart.tsx structure:
   // - Outer div with explicit width in px
   // - position: relative for absolute positioning of overlays
+  // - overflow: hidden clips the extra chart width (price scale padding pushed off-screen)
   // - Chart container div inside with explicit dimensions for correct event patching
   return (
     <div
       style={{
         width: width + 'px',
         position: 'relative',
+        overflow: 'hidden', // Clip the extra chart width that extends past screen edge
       }}
     >
       {/* Chart container - lightweight-charts will render here */}

--- a/apps/strength/stream/Wrapper.tsx
+++ b/apps/strength/stream/Wrapper.tsx
@@ -72,11 +72,11 @@ export function StreamChartWrapper() {
   }
 
   // Match the tradingview wrapper structure:
-  // - overflow-auto allows scrolling if needed
+  // - overflow-hidden prevents scrollbars from creating gaps
   // - w-full ensures full width
   // - The chart is rendered at 2x dimensions, CSS scales it down
   return (
-    <div className="overflow-auto w-full">
+    <div className="overflow-hidden w-full">
       <div className="relative w-full">
         <Chart width={dimensions.width} height={dimensions.height} />
       </div>


### PR DESCRIPTION
Remove the empty space on the right edge of the stream chart.

Default lightweight-charts borders on the price and time scales, along with potential scrollbar issues, were creating unwanted gaps. This PR disables the chart borders and prevents scrollbars to ensure the chart fits perfectly against the screen edges.

---
<a href="https://cursor.com/background-agent?bcId=bc-3844288d-be46-4ba4-82ff-63c07c87c57d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3844288d-be46-4ba4-82ff-63c07c87c57d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

