### PR TITLE
Chart data infinite history

### DIFF
--- a/apps/strength/app/api/v1/strength/route.ts
+++ b/apps/strength/app/api/v1/strength/route.ts
@@ -14,6 +14,7 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams
     const ticker = searchParams.get('ticker')
     const timenow_gt = searchParams.get('timenow_gt')
+    const timenow_lt = searchParams.get('timenow_lt')
     const server_name = searchParams.get('server_name')
     const app_name = searchParams.get('app_name')
     const node_env = searchParams.get('node_env')
@@ -23,6 +24,7 @@ export async function GET(request: NextRequest) {
     const where: any = {}
     if (ticker) where.ticker = ticker
     if (timenow_gt) where.timenow_gt = timenow_gt
+    if (timenow_lt) where.timenow_lt = timenow_lt
     if (server_name) where.server_name = server_name
     if (app_name) where.app_name = app_name
     if (node_env) where.node_env = node_env

--- a/apps/strength/app/historical/page.tsx
+++ b/apps/strength/app/historical/page.tsx
@@ -8,10 +8,15 @@ import { SimpleChart } from '../../historical/SimpleChart'
  * A simple demonstration of lazy loading historical data in lightweight-charts.
  * Scroll left on the chart to load more historical data.
  * The scroll position should be preserved when new data loads.
+ * 
+ * Available tickers (from useChartControlsStore):
+ * - Equities: NQ1!, ES1!, RTY1!
+ * - Metals: GC1!, SI1!, PL1!, HG1!
+ * - Crypto: BTCUSD, SOLUSD
  */
 export default function HistoricalPage() {
-  // Default ticker - can be changed
-  const ticker = 'BTC-USD'
+  // Default ticker - use BTCUSD (not BTC-USD)
+  const ticker = 'BTCUSD'
   
   return (
     <div className="min-h-screen bg-[#0f0f1a]">

--- a/apps/strength/app/historical/page.tsx
+++ b/apps/strength/app/historical/page.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { SimpleChart } from '../../historical/SimpleChart'
+
+/**
+ * Historical Chart Page
+ * 
+ * A simple demonstration of lazy loading historical data in lightweight-charts.
+ * Scroll left on the chart to load more historical data.
+ * The scroll position should be preserved when new data loads.
+ */
+export default function HistoricalPage() {
+  // Default ticker - can be changed
+  const ticker = 'BTC-USD'
+  
+  return (
+    <div className="min-h-screen bg-[#0f0f1a]">
+      <SimpleChart ticker={ticker} />
+    </div>
+  )
+}

--- a/apps/strength/app/page.tsx
+++ b/apps/strength/app/page.tsx
@@ -63,6 +63,19 @@ export default function Page() {
             >
               Streaming chart
             </Link>
+            <Link
+              href="/historical"
+              style={{
+                padding: '14px 18px',
+                borderRadius: '10px',
+                background: '#5a4a8a',
+                color: '#ffffff',
+                textDecoration: 'none',
+                fontWeight: 600,
+              }}
+            >
+              Historical chart (lazy loading demo)
+            </Link>
           </div>
         </div>
       </main>

--- a/apps/strength/historical/AGENTS.md
+++ b/apps/strength/historical/AGENTS.md
@@ -1,0 +1,57 @@
+# Historical Chart Demo
+
+Simple demonstration of lazy loading historical data in lightweight-charts.
+
+## Purpose
+
+This is a minimal implementation to isolate and test the "infinite history" feature without the complexity of the main chart (aggregation, real-time updates, multiple series, etc.).
+
+## Features
+
+1. **Initial Load**: Fetches 24 hours of historical data on mount
+2. **Lazy Loading**: When user scrolls near the beginning (< 50 bars), fetches 2 hours more
+3. **Scroll Preservation**: Saves and restores visible range when prepending data
+
+## How Scroll Preservation Works
+
+When new historical data is loaded:
+
+1. **Before setData()**: Save the current `visibleLogicalRange`
+2. **Calculate offset**: Find how many bars were prepended by comparing timestamps
+3. **After setData()**: Restore the range with offset: `from + prependedCount`, `to + prependedCount`
+
+```typescript
+// Save range before update
+savedLogicalRange = chart.timeScale().getVisibleLogicalRange()
+
+// Calculate prepended bars
+const oldFirstIndex = newData.findIndex(d => d.time >= oldFirstTime)
+prependedCount = oldFirstIndex
+
+// Update data
+series.setData(newData)
+
+// Restore range with offset
+requestAnimationFrame(() => {
+  chart.timeScale().setVisibleLogicalRange({
+    from: savedLogicalRange.from + prependedCount,
+    to: savedLogicalRange.to + prependedCount,
+  })
+})
+```
+
+## Key Implementation Details
+
+- Uses `barsInLogicalRange()` to detect when user scrolls near the beginning
+- Tracks previous data in a ref to compare timestamps
+- Uses `requestAnimationFrame` to ensure chart processes setData before restoring range
+- Uses `isLazyLoadingRef` flag to distinguish lazy loads from initial load
+
+## Files
+
+- **SimpleChart.tsx** - The chart component with all logic
+- **page.tsx** (in `/app/historical/`) - The Next.js page that renders the chart
+
+## Usage
+
+Visit `/historical` to see the demo. Scroll left on the chart to trigger lazy loading.

--- a/apps/strength/historical/SimpleChart.tsx
+++ b/apps/strength/historical/SimpleChart.tsx
@@ -1,0 +1,378 @@
+'use client'
+
+import { useEffect, useRef, useCallback, useState } from 'react'
+import {
+  createChart,
+  IChartApi,
+  ISeriesApi,
+  LineData,
+  LineSeries,
+  Time,
+  LogicalRange,
+} from 'lightweight-charts'
+
+// Configuration
+const LAZY_LOAD_BARS_THRESHOLD = 50 // Load more when fewer than 50 bars before visible area
+const LAZY_LOAD_FETCH_MINUTES = 120 // Fetch 2 hours of data per load
+const INITIAL_FETCH_HOURS = 24 // Initial load: 24 hours of data
+
+interface SimpleChartProps {
+  ticker: string
+}
+
+/**
+ * SimpleChart - A minimal chart implementation demonstrating lazy loading
+ * 
+ * Features:
+ * - Fetches initial historical data on mount
+ * - Detects when user scrolls near the beginning of data
+ * - Loads more historical data (prepending to existing data)
+ * - Preserves scroll position when new data is loaded
+ * 
+ * NO real-time updates, NO aggregation, NO complex state management
+ */
+export function SimpleChart({ ticker }: SimpleChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const chartRef = useRef<IChartApi | null>(null)
+  const seriesRef = useRef<ISeriesApi<'Line'> | null>(null)
+  
+  // Data state
+  const [data, setData] = useState<LineData<Time>[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  
+  // Track earliest timestamp for lazy loading
+  const earliestTimeRef = useRef<number | null>(null)
+  
+  // Track previous data for detecting prepends
+  const prevDataRef = useRef<LineData<Time>[]>([])
+  
+  // Track if we're currently in a lazy load to prevent scroll position restoration from failing
+  const isLazyLoadingRef = useRef(false)
+
+  /**
+   * Fetch data from API
+   */
+  const fetchData = useCallback(async (fromDate: Date, toDate: Date): Promise<LineData<Time>[]> => {
+    const params = new URLSearchParams({
+      ticker,
+      timenow_gt: fromDate.toISOString(),
+      timenow_lt: toDate.toISOString(),
+    })
+    
+    const response = await fetch(`/api/v1/strength?${params}`)
+    const json = await response.json()
+    
+    if (json.error) {
+      throw new Error(json.error)
+    }
+    
+    if (!json.rows || json.rows.length === 0) {
+      return []
+    }
+    
+    // Convert to LineData format
+    // Use 'price' field for the chart value
+    return json.rows
+      .map((row: { timenow: string; price: number }) => ({
+        time: Math.floor(new Date(row.timenow).getTime() / 1000) as Time,
+        value: row.price,
+      }))
+      .filter((d: LineData<Time>) => d.value != null && d.value > 0)
+      .sort((a: LineData<Time>, b: LineData<Time>) => (a.time as number) - (b.time as number))
+  }, [ticker])
+
+  /**
+   * Load initial data
+   */
+  const loadInitialData = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+    
+    try {
+      const toDate = new Date()
+      const fromDate = new Date(toDate.getTime() - INITIAL_FETCH_HOURS * 60 * 60 * 1000)
+      
+      console.log(`[SimpleChart] Loading initial data: ${fromDate.toISOString()} to ${toDate.toISOString()}`)
+      
+      const initialData = await fetchData(fromDate, toDate)
+      
+      if (initialData.length > 0) {
+        earliestTimeRef.current = initialData[0]!.time as number
+        setData(initialData)
+        console.log(`[SimpleChart] Loaded ${initialData.length} data points`)
+      } else {
+        setError('No data available for this ticker')
+      }
+    } catch (err) {
+      console.error('[SimpleChart] Error loading initial data:', err)
+      setError(err instanceof Error ? err.message : 'Failed to load data')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [fetchData])
+
+  /**
+   * Load more historical data (for lazy loading)
+   */
+  const loadMoreHistory = useCallback(async () => {
+    if (isLoadingMore || !earliestTimeRef.current) {
+      return
+    }
+    
+    setIsLoadingMore(true)
+    isLazyLoadingRef.current = true
+    
+    try {
+      const toDate = new Date(earliestTimeRef.current * 1000)
+      const fromDate = new Date(toDate.getTime() - LAZY_LOAD_FETCH_MINUTES * 60 * 1000)
+      
+      console.log(`[SimpleChart] Loading more history: ${fromDate.toISOString()} to ${toDate.toISOString()}`)
+      
+      const historicalData = await fetchData(fromDate, toDate)
+      
+      if (historicalData.length > 0) {
+        // Update earliest time
+        earliestTimeRef.current = historicalData[0]!.time as number
+        
+        // Prepend historical data to existing data
+        setData(prevData => {
+          // Merge and deduplicate by timestamp
+          const dataMap = new Map<number, LineData<Time>>()
+          
+          // Add historical data first
+          for (const point of historicalData) {
+            dataMap.set(point.time as number, point)
+          }
+          
+          // Add existing data (will overwrite if same timestamp)
+          for (const point of prevData) {
+            dataMap.set(point.time as number, point)
+          }
+          
+          // Sort by time
+          const merged = Array.from(dataMap.values()).sort(
+            (a, b) => (a.time as number) - (b.time as number)
+          )
+          
+          console.log(`[SimpleChart] Merged data: ${historicalData.length} new + ${prevData.length} existing = ${merged.length} total`)
+          
+          return merged
+        })
+      } else {
+        console.log('[SimpleChart] No more historical data available')
+      }
+    } catch (err) {
+      console.error('[SimpleChart] Error loading more history:', err)
+    } finally {
+      setIsLoadingMore(false)
+      // Keep isLazyLoadingRef true until the chart update effect runs
+    }
+  }, [fetchData, isLoadingMore])
+
+  /**
+   * Initialize chart
+   */
+  useEffect(() => {
+    if (!containerRef.current) return
+    
+    // Create chart
+    const chart = createChart(containerRef.current, {
+      width: containerRef.current.clientWidth,
+      height: 500,
+      layout: {
+        background: { color: '#1a1a2e' },
+        textColor: '#C3BCDB',
+      },
+      grid: {
+        vertLines: { color: '#333344' },
+        horzLines: { color: '#333344' },
+      },
+      timeScale: {
+        borderColor: '#333344',
+        timeVisible: true,
+        secondsVisible: false,
+      },
+      rightPriceScale: {
+        borderColor: '#333344',
+      },
+    })
+    chartRef.current = chart
+    
+    // Create line series (v5 API)
+    const series = chart.addSeries(LineSeries, {
+      color: '#5B8DEF',
+      lineWidth: 2,
+      priceScaleId: 'right',
+    })
+    seriesRef.current = series
+    
+    // Handle resize
+    const handleResize = () => {
+      if (containerRef.current && chartRef.current) {
+        chartRef.current.applyOptions({
+          width: containerRef.current.clientWidth,
+        })
+      }
+    }
+    window.addEventListener('resize', handleResize)
+    
+    // Load initial data
+    loadInitialData()
+    
+    return () => {
+      window.removeEventListener('resize', handleResize)
+      chart.remove()
+      chartRef.current = null
+      seriesRef.current = null
+    }
+  }, []) // Only on mount - loadInitialData is stable
+
+  /**
+   * Update chart data and handle scroll position preservation
+   */
+  useEffect(() => {
+    if (!seriesRef.current || !chartRef.current || data.length === 0) return
+    
+    const series = seriesRef.current
+    const chart = chartRef.current
+    const prevData = prevDataRef.current
+    
+    // Check if this is a lazy load (prepending historical data)
+    // We need to save the visible range BEFORE updating the data
+    let savedLogicalRange: LogicalRange | null = null
+    let prependedCount = 0
+    
+    if (isLazyLoadingRef.current && prevData.length > 0) {
+      // Save current visible logical range
+      savedLogicalRange = chart.timeScale().getVisibleLogicalRange()
+      
+      // Calculate how many bars were prepended by comparing timestamps
+      const oldFirstTime = prevData[0]?.time as number
+      const newFirstTime = data[0]?.time as number
+      
+      if (newFirstTime < oldFirstTime) {
+        // Find where the old first time appears in the new data
+        const oldFirstIndex = data.findIndex(d => (d.time as number) >= oldFirstTime)
+        if (oldFirstIndex > 0) {
+          prependedCount = oldFirstIndex
+        }
+      }
+      
+      console.log(`[SimpleChart] Lazy load: saved range`, savedLogicalRange, `prepended ${prependedCount} bars`)
+    }
+    
+    // Update the series data
+    series.setData(data)
+    
+    // Update previous data ref for next comparison
+    prevDataRef.current = data
+    
+    // Restore scroll position if this was a lazy load
+    if (isLazyLoadingRef.current && savedLogicalRange && prependedCount > 0) {
+      // Use requestAnimationFrame to ensure the chart has processed the new data
+      requestAnimationFrame(() => {
+        if (chartRef.current && savedLogicalRange) {
+          try {
+            // Offset the logical range by the number of prepended bars
+            const newRange = {
+              from: savedLogicalRange.from + prependedCount,
+              to: savedLogicalRange.to + prependedCount,
+            }
+            
+            console.log(`[SimpleChart] Restoring range: from ${savedLogicalRange.from}-${savedLogicalRange.to} to ${newRange.from}-${newRange.to}`)
+            
+            chartRef.current.timeScale().setVisibleLogicalRange(newRange)
+          } catch (err) {
+            console.warn('[SimpleChart] Failed to restore scroll position:', err)
+          }
+        }
+        
+        // Mark lazy loading as complete
+        isLazyLoadingRef.current = false
+      })
+    } else {
+      isLazyLoadingRef.current = false
+    }
+  }, [data])
+
+  /**
+   * Subscribe to visible range changes for lazy loading detection
+   */
+  useEffect(() => {
+    if (!chartRef.current || !seriesRef.current || data.length === 0) return
+    
+    const chart = chartRef.current
+    const series = seriesRef.current
+    
+    const handleVisibleLogicalRangeChange = (logicalRange: LogicalRange | null) => {
+      if (!logicalRange) return
+      
+      // Don't trigger lazy load while we're already loading
+      if (isLazyLoadingRef.current || isLoadingMore) return
+      
+      // Get bars info to check how many bars are before the visible area
+      const barsInfo = series.barsInLogicalRange(logicalRange)
+      if (!barsInfo) return
+      
+      // If fewer than threshold bars before visible area, load more
+      if (barsInfo.barsBefore !== null && barsInfo.barsBefore < LAZY_LOAD_BARS_THRESHOLD) {
+        console.log(`[SimpleChart] Near beginning: ${barsInfo.barsBefore} bars before visible area`)
+        loadMoreHistory()
+      }
+    }
+    
+    chart.timeScale().subscribeVisibleLogicalRangeChange(handleVisibleLogicalRangeChange)
+    
+    return () => {
+      chart.timeScale().unsubscribeVisibleLogicalRangeChange(handleVisibleLogicalRangeChange)
+    }
+  }, [data.length, isLoadingMore, loadMoreHistory])
+
+  return (
+    <div className="w-full">
+      {/* Header */}
+      <div className="p-4 bg-[#1a1a2e] border-b border-[#333344]">
+        <h1 className="text-xl font-bold text-white mb-2">
+          Simple Historical Chart - {ticker}
+        </h1>
+        <p className="text-sm text-gray-400">
+          Scroll left to load more historical data. The view position will be preserved.
+        </p>
+        <div className="mt-2 text-xs text-gray-500">
+          Data points: {data.length} | 
+          Loading: {isLoading ? 'Initial...' : isLoadingMore ? 'More history...' : 'No'}
+        </div>
+      </div>
+      
+      {/* Error state */}
+      {error && (
+        <div className="p-4 bg-red-900/20 text-red-400 text-center">
+          {error}
+        </div>
+      )}
+      
+      {/* Loading state */}
+      {isLoading && (
+        <div className="p-4 bg-[#1a1a2e] text-gray-400 text-center">
+          Loading initial data...
+        </div>
+      )}
+      
+      {/* Chart container */}
+      <div 
+        ref={containerRef} 
+        className="w-full bg-[#1a1a2e]"
+        style={{ minHeight: '500px' }}
+      />
+      
+      {/* Loading more indicator */}
+      {isLoadingMore && (
+        <div className="absolute top-20 left-4 bg-blue-600 text-white px-3 py-1 rounded text-sm">
+          Loading more history...
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/strength/historical/SimpleChart.tsx
+++ b/apps/strength/historical/SimpleChart.tsx
@@ -94,14 +94,11 @@ export function SimpleChart({ ticker }: SimpleChartProps) {
       const toDate = new Date()
       const fromDate = new Date(toDate.getTime() - INITIAL_FETCH_HOURS * 60 * 60 * 1000)
       
-      console.log(`[SimpleChart] Loading initial data: ${fromDate.toISOString()} to ${toDate.toISOString()}`)
-      
       const initialData = await fetchData(fromDate, toDate)
       
       if (initialData.length > 0) {
         earliestTimeRef.current = initialData[0]!.time as number
         setData(initialData)
-        console.log(`[SimpleChart] Loaded ${initialData.length} data points`)
       } else {
         setError('No data available for this ticker')
       }
@@ -127,8 +124,6 @@ export function SimpleChart({ ticker }: SimpleChartProps) {
     try {
       const toDate = new Date(earliestTimeRef.current * 1000)
       const fromDate = new Date(toDate.getTime() - LAZY_LOAD_FETCH_MINUTES * 60 * 1000)
-      
-      console.log(`[SimpleChart] Loading more history: ${fromDate.toISOString()} to ${toDate.toISOString()}`)
       
       const historicalData = await fetchData(fromDate, toDate)
       
@@ -156,12 +151,8 @@ export function SimpleChart({ ticker }: SimpleChartProps) {
             (a, b) => (a.time as number) - (b.time as number)
           )
           
-          console.log(`[SimpleChart] Merged data: ${historicalData.length} new + ${prevData.length} existing = ${merged.length} total`)
-          
           return merged
         })
-      } else {
-        console.log('[SimpleChart] No more historical data available')
       }
     } catch (err) {
       console.error('[SimpleChart] Error loading more history:', err)
@@ -260,7 +251,6 @@ export function SimpleChart({ ticker }: SimpleChartProps) {
         }
       }
       
-      console.log(`[SimpleChart] Lazy load: saved range`, savedLogicalRange, `prepended ${prependedCount} bars`)
     }
     
     // Update the series data
@@ -281,11 +271,9 @@ export function SimpleChart({ ticker }: SimpleChartProps) {
               to: savedLogicalRange.to + prependedCount,
             }
             
-            console.log(`[SimpleChart] Restoring range: from ${savedLogicalRange.from}-${savedLogicalRange.to} to ${newRange.from}-${newRange.to}`)
-            
             chartRef.current.timeScale().setVisibleLogicalRange(newRange)
-          } catch (err) {
-            console.warn('[SimpleChart] Failed to restore scroll position:', err)
+          } catch {
+            // Scroll position restoration failed - not critical
           }
         }
         
@@ -318,7 +306,6 @@ export function SimpleChart({ ticker }: SimpleChartProps) {
       
       // If fewer than threshold bars before visible area, load more
       if (barsInfo.barsBefore !== null && barsInfo.barsBefore < LAZY_LOAD_BARS_THRESHOLD) {
-        console.log(`[SimpleChart] Near beginning: ${barsInfo.barsBefore} bars before visible area`)
         loadMoreHistory()
       }
     }

--- a/apps/strength/historical/SimpleChart.tsx
+++ b/apps/strength/historical/SimpleChart.tsx
@@ -354,10 +354,19 @@ export function SimpleChart({ ticker }: SimpleChartProps) {
         style={{ minHeight: '500px' }}
       />
       
-      {/* Loading more indicator */}
+      {/* Loading overlay - shown while fetching additional historical data */}
       {isLoadingMore && (
-        <div className="absolute top-20 left-4 bg-blue-600 text-white px-3 py-1 rounded text-sm">
-          Loading more history...
+        <div 
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur-[1px]"
+          style={{ cursor: 'wait' }}
+        >
+          <div className="flex flex-col items-center gap-3">
+            {/* Spinner */}
+            <div className="w-10 h-10 border-4 border-gray-300 border-t-blue-500 rounded-full animate-spin" />
+            <span className="text-sm text-gray-300 bg-black/50 px-3 py-1 rounded">
+              Loading history...
+            </span>
+          </div>
         </div>
       )}
     </div>

--- a/apps/strength/tradingview/AGENTS.md
+++ b/apps/strength/tradingview/AGENTS.md
@@ -76,15 +76,48 @@ When tab is in background, polling may stop. On return:
 - Dynamic window calculates missed time
 - All missing data fetched in one request
 
-### 6. Scroll-to-Pause Polling
+### 6. Smart Pause/Resume (Latest Bar Visibility)
 
-When user scrolls/pans the chart, real-time polling pauses automatically:
+Real-time polling is controlled based on whether the latest bar is visible:
 
-- Chart detects scroll via `subscribeVisibleLogicalRangeChange`
-- Polling pauses to prevent chart jumping while user explores
-- After 30 seconds of no scrolling, polling resumes
-- On resume, all missed data is fetched (using dynamic fetch window)
+- Chart subscribes to `visibleLogicalRangeChange` to detect scroll position
+- When **latest bar is visible**: polling continues, new data auto-scrolls into view
+- When **latest bar is hidden** (user scrolled back): polling pauses automatically
+- This prevents chart jumping while user explores historical data
+- When user scrolls forward to see latest bar again, polling resumes
+- On resume, all missed minutes are fetched (using dynamic fetch window)
 - Visual indicator shows "⏸ paused" in bottom-right corner
+
+### 7. Lazy Loading (Infinite History)
+
+When user scrolls to the beginning of chart data, more historical data loads automatically:
+
+**Trigger:** `barsInLogicalRange().barsBefore < LAZY_LOAD_BARS_THRESHOLD` (50 bars)
+
+**Fetch:** Loads `LAZY_LOAD_FETCH_MINUTES` (120 minutes / 2 hours) of additional history
+
+**Scroll Preservation:** When historical data is prepended, the view position is preserved:
+1. Save `visibleLogicalRange` before `setData()`
+2. After update, restore range with offset: `from + prependedBarsCount`, `to + prependedBarsCount`
+
+**Data Flow:**
+```
+User scrolls near beginning
+      ↓
+Chart.tsx: onNeedMoreHistory callback
+      ↓
+SyncedCharts: handleNeedMoreHistory
+      ↓
+useStrengthData: fetchHistoricalDataBefore(earliestDataTime, minutes)
+      ↓
+FetchStrengthData: API fetch for older data
+      ↓
+Merge with existing data (prepend)
+      ↓
+Trigger aggregation worker
+      ↓
+Chart updates with scroll position preserved
+```
 
 ## Chart Lines
 

--- a/apps/strength/tradingview/SyncedCharts.tsx
+++ b/apps/strength/tradingview/SyncedCharts.tsx
@@ -197,7 +197,6 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
     // Set a fallback timer to resume polling after long inactivity
     // This is a safety net in case onLatestBarVisibilityChange doesn't fire
     scrollResumeTimerRef.current = setTimeout(() => {
-      console.log('[SyncedCharts] Scroll inactivity fallback - resuming polling')
       setPollingPaused(false)
       scrollResumeTimerRef.current = null
     }, SCROLL_PAUSE_RESUME_MS)
@@ -218,14 +217,12 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
     if (isVisible) {
       // Latest bar is visible - resume real-time updates
       if (pollingPaused) {
-        console.log('[SyncedCharts] Latest bar visible - resuming polling')
         setPollingPaused(false)
       }
     } else {
       // Latest bar is NOT visible - pause real-time updates
       // This prevents the chart from jumping to the latest data while user explores history
       if (!pollingPaused) {
-        console.log('[SyncedCharts] Latest bar hidden - pausing polling')
         setPollingPaused(true)
       }
     }
@@ -236,20 +233,11 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
    * Called when user scrolls near the beginning of the chart data
    */
   const handleNeedMoreHistory = useCallback(() => {
-    if (!earliestDataTime) {
-      console.log('[SyncedCharts] No earliest data time yet, skipping')
-      return
-    }
-    
-    if (isLoadingHistorical) {
-      console.log('[SyncedCharts] Already loading historical data, skipping')
+    if (!earliestDataTime || isLoadingHistorical) {
       return
     }
 
     const fetchMinutes = LAZY_LOAD_FETCH_HOURS * 60 // Convert hours to minutes
-    console.log(
-      `[SyncedCharts] Need more history - fetching ${LAZY_LOAD_FETCH_HOURS} hours (${fetchMinutes} minutes) before ${earliestDataTime.toISOString()}`
-    )
 
     // Fetch more historical data before the earliest data point
     fetchHistoricalDataBefore(earliestDataTime, fetchMinutes)
@@ -272,7 +260,7 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
   const handleAggregationResult = useCallback(
     (
       result: AggregationResult,
-      processingTimeMs: number,
+      _processingTimeMs: number,
       resultDataVersion: number
     ) => {
       // Mark processing as complete (use ref to avoid re-triggering effects)
@@ -337,14 +325,6 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
       setPriceTickers(result.priceTickers)
       setStrengthIndicator(strengthIndicator)
       setPriceIndicator(priceIndicator)
-
-      if (processingTimeMs > 100) {
-        console.log(
-          `[Worker] Aggregation v${resultDataVersion} completed in ${processingTimeMs.toFixed(
-            1
-          )}ms`
-        )
-      }
     },
     [
       chartTickers,
@@ -583,7 +563,6 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
     if (!initialTimeRangeSetRef.current || hoursBackChanged) {
       const newRange = calculateTimeRange(rawData, parseInt(hoursBack))
       if (newRange && newRange.from < newRange.to) {
-        console.log(`[SyncedCharts] Setting time range (initial=${!initialTimeRangeSetRef.current}, hoursBackChanged=${hoursBackChanged})`)
         setTimeRange(newRange)
         initialTimeRangeSetRef.current = true
       }

--- a/apps/strength/tradingview/SyncedCharts.tsx
+++ b/apps/strength/tradingview/SyncedCharts.tsx
@@ -115,6 +115,10 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
   const [pollingPaused, setPollingPaused] = useState(false)
   const scrollResumeTimerRef = useRef<NodeJS.Timeout | null>(null)
 
+  // Track if initial time range has been set - prevents resetting zoom on real-time updates
+  const initialTimeRangeSetRef = useRef(false)
+  const lastHoursBackRef = useRef<string | null>(null)
+
   // Zustand store
   const {
     hoursBack,
@@ -394,6 +398,9 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
     // Reset debounce timer so initial load is fast
     lastAggregationTimeRef.current = 0
 
+    // Reset time range initialization flag so new ticker gets proper initial time range
+    initialTimeRangeSetRef.current = false
+
     // Clear chart data immediately when version changes
     // This prevents showing old data while new data loads
     if (chartDataVersionRef.current !== dataVersion) {
@@ -551,9 +558,10 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
    * - Historical data was just loaded (would cause chart to jump)
    * 
    * Only update timeRange when:
-   * - Initial data load (timeRange is null)
+   * - Initial data load (first time we have data)
    * - User changes hoursBack setting
-   * - Real-time data arrives (polling is active)
+   * 
+   * We do NOT reset time range on real-time updates to preserve user's zoom level.
    */
   useEffect(() => {
     if (!chartData.strengthAverage || chartData.strengthAverage.length === 0)
@@ -565,10 +573,23 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
       return
     }
 
-    const newRange = calculateTimeRange(rawData, parseInt(hoursBack))
-    if (newRange && newRange.from < newRange.to) {
-      setTimeRange(newRange)
+    // Check if hoursBack changed (user action)
+    const hoursBackChanged = lastHoursBackRef.current !== null && lastHoursBackRef.current !== hoursBack
+    lastHoursBackRef.current = hoursBack
+
+    // Only set time range on:
+    // 1. Initial load (initialTimeRangeSetRef.current is false)
+    // 2. User changed hoursBack
+    if (!initialTimeRangeSetRef.current || hoursBackChanged) {
+      const newRange = calculateTimeRange(rawData, parseInt(hoursBack))
+      if (newRange && newRange.from < newRange.to) {
+        console.log(`[SyncedCharts] Setting time range (initial=${!initialTimeRangeSetRef.current}, hoursBackChanged=${hoursBackChanged})`)
+        setTimeRange(newRange)
+        initialTimeRangeSetRef.current = true
+      }
     }
+    // Real-time data updates (rawData changes) do NOT reset time range
+    // This preserves user's zoom level
   }, [hoursBack, rawData, chartData.strengthAverage, setTimeRange, pollingPaused])
 
   /**

--- a/apps/strength/tradingview/SyncedCharts.tsx
+++ b/apps/strength/tradingview/SyncedCharts.tsx
@@ -7,7 +7,7 @@ import { Chart, ChartRef } from './components/Chart'
 import { LoadingState, ErrorState } from './components/ChartStates'
 import { UpdatedTime } from './components/UpdatedTime'
 import { useChartControlsStore } from './state/useChartControlsStore'
-import { COLORS, FETCH_DATA_HOURS_BACK } from './constants'
+import { COLORS, FETCH_DATA_HOURS_BACK, LAZY_LOAD_FETCH_MINUTES } from './constants'
 import {
   useAggregationWorker,
   AggregationResult,
@@ -158,9 +158,31 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
   const pendingAggregationRef = useRef<NodeJS.Timeout | null>(null)
 
   /**
-   * Handle user scroll/pan on chart
-   * Pauses real-time polling while user is interacting with the chart.
-   * After 30 seconds of no scrolling, polling resumes automatically.
+   * Controlled data fetching hook
+   * Handles ticker changes, loading state, and real-time updates
+   * Paused when user is scrolling/panning the chart (latest bar not visible)
+   */
+  const {
+    rawData,
+    dataState,
+    error,
+    lastUpdateTime,
+    dataVersion,
+    earliestDataTime,
+    latestDataTime,
+    fetchHistoricalDataBefore,
+    isLoadingHistorical,
+  } = useStrengthData({
+    tickers: chartTickers,
+    enabled: chartTickers.length > 0,
+    maxDataHours: FETCH_DATA_HOURS_BACK,
+    updateIntervalMs: 10000,
+    paused: pollingPaused,
+  })
+
+  /**
+   * Handle user scroll/pan on chart (legacy - kept for general scroll detection)
+   * The smart pause/resume is now handled by onLatestBarVisibilityChange
    */
   const handleUserScroll = useCallback(() => {
     // Clear any existing resume timer
@@ -168,19 +190,59 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
       clearTimeout(scrollResumeTimerRef.current)
     }
 
-    // Pause polling if not already paused
-    if (!pollingPaused) {
-      setPollingPaused(true)
-      console.log('[SyncedCharts] User scrolling - polling paused')
-    }
-
-    // Set timer to resume polling after inactivity
+    // Set a fallback timer to resume polling after long inactivity
+    // This is a safety net in case onLatestBarVisibilityChange doesn't fire
     scrollResumeTimerRef.current = setTimeout(() => {
-      console.log('[SyncedCharts] Scroll inactivity - resuming polling')
+      console.log('[SyncedCharts] Scroll inactivity fallback - resuming polling')
       setPollingPaused(false)
       scrollResumeTimerRef.current = null
     }, SCROLL_PAUSE_RESUME_MS)
+  }, [])
+
+  /**
+   * Handle visibility change of the latest bar
+   * When the latest bar is visible, we should poll for new data (auto-scroll behavior)
+   * When the latest bar is NOT visible (user scrolled back), pause polling
+   */
+  const handleLatestBarVisibilityChange = useCallback((isVisible: boolean) => {
+    // Clear any pending scroll resume timer
+    if (scrollResumeTimerRef.current) {
+      clearTimeout(scrollResumeTimerRef.current)
+      scrollResumeTimerRef.current = null
+    }
+
+    if (isVisible) {
+      // Latest bar is visible - resume real-time updates
+      if (pollingPaused) {
+        console.log('[SyncedCharts] Latest bar visible - resuming polling')
+        setPollingPaused(false)
+      }
+    } else {
+      // Latest bar is NOT visible - pause real-time updates
+      // This prevents the chart from jumping to the latest data while user explores history
+      if (!pollingPaused) {
+        console.log('[SyncedCharts] Latest bar hidden - pausing polling')
+        setPollingPaused(true)
+      }
+    }
   }, [pollingPaused])
+
+  /**
+   * Handle request for more historical data (lazy loading)
+   * Called when user scrolls near the beginning of the chart data
+   */
+  const handleNeedMoreHistory = useCallback(() => {
+    if (!earliestDataTime || isLoadingHistorical) {
+      return
+    }
+
+    console.log(
+      `[SyncedCharts] Need more history - fetching ${LAZY_LOAD_FETCH_MINUTES} minutes before ${earliestDataTime.toISOString()}`
+    )
+
+    // Fetch more historical data before the earliest data point
+    fetchHistoricalDataBefore(earliestDataTime, LAZY_LOAD_FETCH_MINUTES)
+  }, [earliestDataTime, isLoadingHistorical, fetchHistoricalDataBefore])
 
   // Cleanup scroll timer on unmount
   useEffect(() => {
@@ -190,20 +252,6 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
       }
     }
   }, [])
-
-  /**
-   * Controlled data fetching hook
-   * Handles ticker changes, loading state, and real-time updates
-   * Paused when user is scrolling/panning the chart
-   */
-  const { rawData, dataState, error, lastUpdateTime, dataVersion } =
-    useStrengthData({
-      tickers: chartTickers,
-      enabled: chartTickers.length > 0,
-      maxDataHours: FETCH_DATA_HOURS_BACK,
-      updateIntervalMs: 10000,
-      paused: pollingPaused,
-    })
 
   /**
    * Handle aggregation results from the Web Worker
@@ -568,6 +616,9 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
           height={availableHeight}
           timeRange={chartTimeRange}
           onUserScroll={handleUserScroll}
+          onNeedMoreHistory={handleNeedMoreHistory}
+          onLatestBarVisibilityChange={handleLatestBarVisibilityChange}
+          isLoadingHistorical={isLoadingHistorical}
         />
       )}
 

--- a/apps/strength/tradingview/SyncedCharts.tsx
+++ b/apps/strength/tradingview/SyncedCharts.tsx
@@ -644,6 +644,22 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
         />
       )}
 
+      {/* Loading overlay - shown while fetching additional historical data */}
+      {isLoadingHistorical && (
+        <div 
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur-[1px]"
+          style={{ cursor: 'wait' }}
+        >
+          <div className="flex flex-col items-center gap-3">
+            {/* Spinner */}
+            <div className="w-10 h-10 border-4 border-gray-300 border-t-blue-500 rounded-full animate-spin" />
+            <span className="text-sm text-gray-300 bg-black/50 px-3 py-1 rounded">
+              Loading history...
+            </span>
+          </div>
+        </div>
+      )}
+
       {/* Last updated time (shows paused indicator when user is scrolling) */}
       <UpdatedTime
         isRealtime={dataState === 'ready'}

--- a/apps/strength/tradingview/SyncedCharts.tsx
+++ b/apps/strength/tradingview/SyncedCharts.tsx
@@ -538,16 +538,31 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
 
   /**
    * Effect: Calculate time range when data is ready
+   * 
+   * IMPORTANT: Do NOT update timeRange when:
+   * - Polling is paused (user is viewing historical data)
+   * - Historical data was just loaded (would cause chart to jump)
+   * 
+   * Only update timeRange when:
+   * - Initial data load (timeRange is null)
+   * - User changes hoursBack setting
+   * - Real-time data arrives (polling is active)
    */
   useEffect(() => {
     if (!chartData.strengthAverage || chartData.strengthAverage.length === 0)
       return
 
+    // Don't recalculate time range when polling is paused
+    // This prevents the chart from jumping when historical data is loaded
+    if (pollingPaused) {
+      return
+    }
+
     const newRange = calculateTimeRange(rawData, parseInt(hoursBack))
     if (newRange && newRange.from < newRange.to) {
       setTimeRange(newRange)
     }
-  }, [hoursBack, rawData, chartData.strengthAverage, setTimeRange])
+  }, [hoursBack, rawData, chartData.strengthAverage, setTimeRange, pollingPaused])
 
   /**
    * Determine what to render based on state

--- a/apps/strength/tradingview/SyncedCharts.tsx
+++ b/apps/strength/tradingview/SyncedCharts.tsx
@@ -7,7 +7,7 @@ import { Chart, ChartRef } from './components/Chart'
 import { LoadingState, ErrorState } from './components/ChartStates'
 import { UpdatedTime } from './components/UpdatedTime'
 import { useChartControlsStore } from './state/useChartControlsStore'
-import { COLORS, FETCH_DATA_HOURS_BACK, LAZY_LOAD_FETCH_MINUTES } from './constants'
+import { COLORS, FETCH_DATA_HOURS_BACK, LAZY_LOAD_FETCH_HOURS } from './constants'
 import {
   useAggregationWorker,
   AggregationResult,
@@ -232,16 +232,23 @@ export function SyncedCharts({ availableHeight }: SyncedChartsProps) {
    * Called when user scrolls near the beginning of the chart data
    */
   const handleNeedMoreHistory = useCallback(() => {
-    if (!earliestDataTime || isLoadingHistorical) {
+    if (!earliestDataTime) {
+      console.log('[SyncedCharts] No earliest data time yet, skipping')
+      return
+    }
+    
+    if (isLoadingHistorical) {
+      console.log('[SyncedCharts] Already loading historical data, skipping')
       return
     }
 
+    const fetchMinutes = LAZY_LOAD_FETCH_HOURS * 60 // Convert hours to minutes
     console.log(
-      `[SyncedCharts] Need more history - fetching ${LAZY_LOAD_FETCH_MINUTES} minutes before ${earliestDataTime.toISOString()}`
+      `[SyncedCharts] Need more history - fetching ${LAZY_LOAD_FETCH_HOURS} hours (${fetchMinutes} minutes) before ${earliestDataTime.toISOString()}`
     )
 
     // Fetch more historical data before the earliest data point
-    fetchHistoricalDataBefore(earliestDataTime, LAZY_LOAD_FETCH_MINUTES)
+    fetchHistoricalDataBefore(earliestDataTime, fetchMinutes)
   }, [earliestDataTime, isLoadingHistorical, fetchHistoricalDataBefore])
 
   // Cleanup scroll timer on unmount

--- a/apps/strength/tradingview/components/Chart.tsx
+++ b/apps/strength/tradingview/components/Chart.tsx
@@ -370,6 +370,39 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
           TIME_RANGE_HIGHLIGHTS
         )
 
+        // Detect if this is a historical data prepend (new data has earlier timestamps)
+        // This happens when user scrolls back and we lazy-load more history
+        let isHistoricalPrepend = false
+        let prependedBarsCount = 0
+        let savedLogicalRange: LogicalRange | null = null
+
+        if (
+          prevData &&
+          prevData.length > 0 &&
+          currentData.length > prevData.length &&
+          chartRef.current
+        ) {
+          const prevFirstTime = prevData[0]!.time as number
+          const currentFirstTime = currentData[0]!.time as number
+
+          // If the new data has an earlier first timestamp, historical data was prepended
+          if (currentFirstTime < prevFirstTime) {
+            isHistoricalPrepend = true
+            // Count how many bars were prepended
+            // Find the index in currentData where the old first timestamp appears
+            const oldFirstIndex = currentData.findIndex(
+              (d) => (d.time as number) >= prevFirstTime
+            )
+            if (oldFirstIndex > 0) {
+              prependedBarsCount = oldFirstIndex
+            }
+            // Save the current visible logical range before updating
+            savedLogicalRange = chartRef.current
+              .timeScale()
+              .getVisibleLogicalRange()
+          }
+        }
+
         // Use efficient update strategy
         const updated = updateSeriesEfficiently(
           strengthAverageSeriesRef.current,
@@ -410,6 +443,35 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
               ])
             }
           }
+
+          // Restore scroll position after historical data prepend
+          // When historical data is prepended, the logical indices shift
+          // We need to adjust the visible range by the number of prepended bars
+          if (
+            isHistoricalPrepend &&
+            savedLogicalRange &&
+            prependedBarsCount > 0 &&
+            chartRef.current
+          ) {
+            // Use requestAnimationFrame to ensure the chart has processed setData
+            requestAnimationFrame(() => {
+              if (chartRef.current && savedLogicalRange) {
+                try {
+                  // Offset the logical range by the number of prepended bars
+                  // This keeps the same data points visible on screen
+                  chartRef.current.timeScale().setVisibleLogicalRange({
+                    from: savedLogicalRange.from + prependedBarsCount,
+                    to: savedLogicalRange.to + prependedBarsCount,
+                  })
+                } catch (error) {
+                  console.warn(
+                    'Failed to restore scroll position after historical load:',
+                    error
+                  )
+                }
+              }
+            })
+          }
         }
 
         // Create time markers on first data load
@@ -419,6 +481,7 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
 
         // Apply time range on first data load (when we had no previous data)
         // Only do this if we have actual data to display
+        // Skip if this was a historical prepend (we already handled scroll position above)
         if (
           updated &&
           !prevData &&

--- a/apps/strength/tradingview/components/Chart.tsx
+++ b/apps/strength/tradingview/components/Chart.tsx
@@ -121,6 +121,7 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
     // Refs for lazy loading and visibility tracking
     const lastLatestBarVisibleRef = useRef<boolean>(true)
     const isLoadingHistoricalRef = useRef<boolean>(false)
+    const lastLazyLoadTimeRef = useRef<number>(0)
     // Keep refs to callbacks to avoid stale closures
     const onNeedMoreHistoryRef = useRef(onNeedMoreHistory)
     const onLatestBarVisibilityChangeRef = useRef(onLatestBarVisibilityChange)
@@ -793,12 +794,18 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
 
         // Check if we need to load more historical data
         // barsBefore tells us how many bars exist before the visible area
+        const now = Date.now()
+        const timeSinceLastLoad = now - lastLazyLoadTimeRef.current
+        const LAZY_LOAD_COOLDOWN_MS = 3000 // 3 second cooldown between loads
+        
         if (
           barsInfo.barsBefore !== null &&
           barsInfo.barsBefore < LAZY_LOAD_BARS_THRESHOLD &&
-          !isLoadingHistoricalRef.current
+          !isLoadingHistoricalRef.current &&
+          timeSinceLastLoad > LAZY_LOAD_COOLDOWN_MS
         ) {
           // User scrolled near the beginning - request more history
+          lastLazyLoadTimeRef.current = now
           onNeedMoreHistoryRef.current?.()
         }
 

--- a/apps/strength/tradingview/components/Chart.tsx
+++ b/apps/strength/tradingview/components/Chart.tsx
@@ -823,16 +823,18 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
           }
         }
 
-        // Check if the latest bar is visible
-        // The last bar is at logical index (data.length - 1)
-        // If logicalRange.to is greater than or equal to (data.length - 1), the latest bar is visible
-        const lastBarLogicalIndex = data.length - 1
-        // Use a buffer of 10 bars to account for slight scrolling
-        const isLatestBarVisible = logicalRange.to >= lastBarLogicalIndex - 10
+        // Check if the latest ACTUAL data bar is visible (not the future-padded bars)
+        // The data is extended 12 hours (720 bars) into the future with the last value
+        // So the actual latest data is at index (data.length - 1 - 720)
+        // We use a generous buffer to resume polling when user scrolls "near" the end
+        const FUTURE_PADDING_BARS = 720 // 12 hours * 60 minutes
+        const VISIBILITY_BUFFER = 60 // 1 hour buffer - resume polling when within 1 hour of latest data
+        const lastActualDataIndex = data.length - 1 - FUTURE_PADDING_BARS
+        const isLatestBarVisible = logicalRange.to >= lastActualDataIndex - VISIBILITY_BUFFER
 
         // Only notify if visibility changed
         if (isLatestBarVisible !== lastLatestBarVisibleRef.current) {
-          console.log(`[Chart] Latest bar visibility changed: ${isLatestBarVisible}, logicalRange.to=${logicalRange.to.toFixed(0)}, lastBarIndex=${lastBarLogicalIndex}`)
+          console.log(`[Chart] Latest bar visibility changed: ${isLatestBarVisible}, logicalRange.to=${logicalRange.to.toFixed(0)}, lastActualDataIndex=${lastActualDataIndex}`)
           lastLatestBarVisibleRef.current = isLatestBarVisible
           onLatestBarVisibilityChangeRef.current?.(isLatestBarVisible)
         }

--- a/apps/strength/tradingview/components/Chart.tsx
+++ b/apps/strength/tradingview/components/Chart.tsx
@@ -827,10 +827,12 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
         // The last bar is at logical index (data.length - 1)
         // If logicalRange.to is greater than or equal to (data.length - 1), the latest bar is visible
         const lastBarLogicalIndex = data.length - 1
-        const isLatestBarVisible = logicalRange.to >= lastBarLogicalIndex - 1 // -1 for some buffer
+        // Use a buffer of 10 bars to account for slight scrolling
+        const isLatestBarVisible = logicalRange.to >= lastBarLogicalIndex - 10
 
         // Only notify if visibility changed
         if (isLatestBarVisible !== lastLatestBarVisibleRef.current) {
+          console.log(`[Chart] Latest bar visibility changed: ${isLatestBarVisible}, logicalRange.to=${logicalRange.to.toFixed(0)}, lastBarIndex=${lastBarLogicalIndex}`)
           lastLatestBarVisibleRef.current = isLatestBarVisible
           onLatestBarVisibilityChangeRef.current?.(isLatestBarVisible)
         }

--- a/apps/strength/tradingview/components/Chart.tsx
+++ b/apps/strength/tradingview/components/Chart.tsx
@@ -23,7 +23,7 @@ import ChartTitle from './ChartTitle'
 import { NoDataState } from './ChartStates'
 import classes from '../classes.module.scss'
 import { prepareDataWithRequiredTimestamps } from '../lib/primitives/forwardFillData'
-import { TIME_RANGE_HIGHLIGHTS, SHOW_100_LINES, LAZY_LOAD_BARS_THRESHOLD } from '../constants'
+import { TIME_RANGE_HIGHLIGHTS, SHOW_100_LINES, LAZY_LOAD_BARS_THRESHOLD, LAZY_LOAD_COOLDOWN_MS, FUTURE_PADDING_BARS } from '../constants'
 import {
   strengthIntervalsAll as STRENGTH_INTERVALS,
   StrengthIntervalsData,
@@ -469,12 +469,8 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
                     from: savedLogicalRange.from + prependedBarsCount,
                     to: savedLogicalRange.to + prependedBarsCount,
                   })
-                  console.log(`[Chart] Restored scroll position: prepended ${prependedBarsCount} bars, new range ${savedLogicalRange.from + prependedBarsCount} to ${savedLogicalRange.to + prependedBarsCount}`)
-                } catch (error) {
-                  console.warn(
-                    'Failed to restore scroll position after historical load:',
-                    error
-                  )
+                } catch {
+                  // Scroll position restoration failed - not critical, chart will show default view
                 }
               }
               
@@ -807,7 +803,6 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
         // barsBefore tells us how many bars exist before the visible area
         const now = Date.now()
         const timeSinceLastLoad = now - lastLazyLoadTimeRef.current
-        const LAZY_LOAD_COOLDOWN_MS = 2000 // 2 second cooldown between loads
         
         if (barsInfo.barsBefore !== null && barsInfo.barsBefore < LAZY_LOAD_BARS_THRESHOLD) {
           // Check why we might not load
@@ -817,24 +812,21 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
             // Cooldown active - don't log spam
           } else {
             // All conditions met - request more history
-            console.log(`[Chart] Triggering lazy load: barsBefore=${barsInfo.barsBefore}, threshold=${LAZY_LOAD_BARS_THRESHOLD}`)
             lastLazyLoadTimeRef.current = now
             onNeedMoreHistoryRef.current?.()
           }
         }
 
         // Check if the latest ACTUAL data bar is visible (not the future-padded bars)
-        // The data is extended 12 hours (720 bars) into the future with the last value
-        // So the actual latest data is at index (data.length - 1 - 720)
+        // The data is extended into the future with the last value (FUTURE_PADDING_BARS)
+        // So the actual latest data is at index (data.length - 1 - FUTURE_PADDING_BARS)
         // We use a generous buffer to resume polling when user scrolls "near" the end
-        const FUTURE_PADDING_BARS = 720 // 12 hours * 60 minutes
         const VISIBILITY_BUFFER = 60 // 1 hour buffer - resume polling when within 1 hour of latest data
-        const lastActualDataIndex = data.length - 1 - FUTURE_PADDING_BARS
+        const lastActualDataIndex = Math.max(0, data.length - 1 - FUTURE_PADDING_BARS)
         const isLatestBarVisible = logicalRange.to >= lastActualDataIndex - VISIBILITY_BUFFER
 
         // Only notify if visibility changed
         if (isLatestBarVisible !== lastLatestBarVisibleRef.current) {
-          console.log(`[Chart] Latest bar visibility changed: ${isLatestBarVisible}, logicalRange.to=${logicalRange.to.toFixed(0)}, lastActualDataIndex=${lastActualDataIndex}`)
           lastLatestBarVisibleRef.current = isLatestBarVisible
           onLatestBarVisibilityChangeRef.current?.(isLatestBarVisible)
         }
@@ -859,7 +851,6 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
       // Skip if we just restored scroll position after historical prepend
       // This prevents the timeRange from overriding our scroll restoration
       if (skipTimeRangeUpdateRef.current) {
-        console.log('[Chart] Skipping timeRange update - scroll position was just restored')
         return
       }
 

--- a/apps/strength/tradingview/components/Chart.tsx
+++ b/apps/strength/tradingview/components/Chart.tsx
@@ -796,17 +796,20 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
         // barsBefore tells us how many bars exist before the visible area
         const now = Date.now()
         const timeSinceLastLoad = now - lastLazyLoadTimeRef.current
-        const LAZY_LOAD_COOLDOWN_MS = 3000 // 3 second cooldown between loads
+        const LAZY_LOAD_COOLDOWN_MS = 2000 // 2 second cooldown between loads
         
-        if (
-          barsInfo.barsBefore !== null &&
-          barsInfo.barsBefore < LAZY_LOAD_BARS_THRESHOLD &&
-          !isLoadingHistoricalRef.current &&
-          timeSinceLastLoad > LAZY_LOAD_COOLDOWN_MS
-        ) {
-          // User scrolled near the beginning - request more history
-          lastLazyLoadTimeRef.current = now
-          onNeedMoreHistoryRef.current?.()
+        if (barsInfo.barsBefore !== null && barsInfo.barsBefore < LAZY_LOAD_BARS_THRESHOLD) {
+          // Check why we might not load
+          if (isLoadingHistoricalRef.current) {
+            // Already loading - this is expected, don't log spam
+          } else if (timeSinceLastLoad <= LAZY_LOAD_COOLDOWN_MS) {
+            // Cooldown active - don't log spam
+          } else {
+            // All conditions met - request more history
+            console.log(`[Chart] Triggering lazy load: barsBefore=${barsInfo.barsBefore}, threshold=${LAZY_LOAD_BARS_THRESHOLD}`)
+            lastLazyLoadTimeRef.current = now
+            onNeedMoreHistoryRef.current?.()
+          }
         }
 
         // Check if the latest bar is visible

--- a/apps/strength/tradingview/components/Chart.tsx
+++ b/apps/strength/tradingview/components/Chart.tsx
@@ -122,6 +122,8 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
     const lastLatestBarVisibleRef = useRef<boolean>(true)
     const isLoadingHistoricalRef = useRef<boolean>(false)
     const lastLazyLoadTimeRef = useRef<number>(0)
+    // Flag to skip timeRange application after scroll position restoration
+    const skipTimeRangeUpdateRef = useRef<boolean>(false)
     // Keep refs to callbacks to avoid stale closures
     const onNeedMoreHistoryRef = useRef(onNeedMoreHistory)
     const onLatestBarVisibilityChangeRef = useRef(onLatestBarVisibilityChange)
@@ -454,6 +456,9 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
             prependedBarsCount > 0 &&
             chartRef.current
           ) {
+            // Set flag to prevent timeRange effect from overriding our scroll restoration
+            skipTimeRangeUpdateRef.current = true
+            
             // Use requestAnimationFrame to ensure the chart has processed setData
             requestAnimationFrame(() => {
               if (chartRef.current && savedLogicalRange) {
@@ -464,6 +469,7 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
                     from: savedLogicalRange.from + prependedBarsCount,
                     to: savedLogicalRange.to + prependedBarsCount,
                   })
+                  console.log(`[Chart] Restored scroll position: prepended ${prependedBarsCount} bars, new range ${savedLogicalRange.from + prependedBarsCount} to ${savedLogicalRange.to + prependedBarsCount}`)
                 } catch (error) {
                   console.warn(
                     'Failed to restore scroll position after historical load:',
@@ -471,6 +477,11 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
                   )
                 }
               }
+              
+              // Clear the flag after a short delay to allow for any pending effects
+              setTimeout(() => {
+                skipTimeRangeUpdateRef.current = false
+              }, 100)
             })
           }
         }
@@ -840,6 +851,13 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
     // Update time range when it changes
     useEffect(() => {
       if (!chartRef.current || !timeRange || !hasInitialized.current) return
+
+      // Skip if we just restored scroll position after historical prepend
+      // This prevents the timeRange from overriding our scroll restoration
+      if (skipTimeRangeUpdateRef.current) {
+        console.log('[Chart] Skipping timeRange update - scroll position was just restored')
+        return
+      }
 
       // Validate time range before setting
       if (timeRange.from >= timeRange.to) {

--- a/apps/strength/tradingview/components/Chart.tsx
+++ b/apps/strength/tradingview/components/Chart.tsx
@@ -13,6 +13,7 @@ import {
   LineSeries,
   ISeriesApi,
   Time,
+  LogicalRange,
 } from 'lightweight-charts'
 import { getChartConfig, getLineSeriesConfig } from '../lib/chartConfig'
 import { updateSeriesEfficiently } from '../lib/chartUtils'
@@ -22,7 +23,7 @@ import ChartTitle from './ChartTitle'
 import { NoDataState } from './ChartStates'
 import classes from '../classes.module.scss'
 import { prepareDataWithRequiredTimestamps } from '../lib/primitives/forwardFillData'
-import { TIME_RANGE_HIGHLIGHTS, SHOW_100_LINES } from '../constants'
+import { TIME_RANGE_HIGHLIGHTS, SHOW_100_LINES, LAZY_LOAD_BARS_THRESHOLD } from '../constants'
 import {
   strengthIntervalsAll as STRENGTH_INTERVALS,
   StrengthIntervalsData,
@@ -46,6 +47,12 @@ interface ChartProps {
   timeRange?: { from: Time; to: Time } | null
   /** Called when user scrolls/pans the chart (visible time range changes) */
   onUserScroll?: () => void
+  /** Called when user scrolls near the beginning of data and needs more historical data */
+  onNeedMoreHistory?: () => void
+  /** Called when the visibility of the latest bar changes (true = latest bar is visible, false = scrolled away) */
+  onLatestBarVisibilityChange?: (isVisible: boolean) => void
+  /** Whether historical data is currently being loaded (to prevent duplicate requests) */
+  isLoadingHistorical?: boolean
 }
 
 export interface ChartRef {
@@ -73,6 +80,9 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
       height,
       timeRange,
       onUserScroll,
+      onNeedMoreHistory,
+      onLatestBarVisibilityChange,
+      isLoadingHistorical = false,
     },
     ref
   ) => {
@@ -107,6 +117,24 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
     const lastPriceTickersRef = useRef<PriceTickersData>({})
     const lastStrengthIndicatorRef = useRef<LineData[] | null>(null)
     const lastPriceIndicatorRef = useRef<LineData[] | null>(null)
+    
+    // Refs for lazy loading and visibility tracking
+    const lastLatestBarVisibleRef = useRef<boolean>(true)
+    const isLoadingHistoricalRef = useRef<boolean>(false)
+    // Keep refs to callbacks to avoid stale closures
+    const onNeedMoreHistoryRef = useRef(onNeedMoreHistory)
+    const onLatestBarVisibilityChangeRef = useRef(onLatestBarVisibilityChange)
+    
+    // Update callback refs when they change
+    useEffect(() => {
+      onNeedMoreHistoryRef.current = onNeedMoreHistory
+      onLatestBarVisibilityChangeRef.current = onLatestBarVisibilityChange
+    }, [onNeedMoreHistory, onLatestBarVisibilityChange])
+    
+    // Update loading ref when prop changes
+    useEffect(() => {
+      isLoadingHistoricalRef.current = isLoadingHistorical
+    }, [isLoadingHistorical])
 
     // Use extracted hooks
     const { createTimeMarkers, markersInitialized } = useTimeMarkers()
@@ -674,6 +702,67 @@ export const Chart = forwardRef<ChartRef, ChartProps>(
         height,
       })
     }, [width, height])
+
+    // Subscribe to visible range changes for lazy loading and pause/resume control
+    useEffect(() => {
+      if (!chartRef.current || !hasInitialized.current) return
+      if (!strengthAverageSeriesRef.current) return
+
+      const chart = chartRef.current
+      const series = strengthAverageSeriesRef.current
+
+      /**
+       * Handle visible logical range changes
+       * - Detects when user scrolls near the beginning to trigger lazy loading
+       * - Detects when the latest bar is visible/hidden to control polling
+       */
+      const handleVisibleLogicalRangeChange = (
+        logicalRange: LogicalRange | null
+      ) => {
+        if (!logicalRange) return
+
+        const data = lastStrengthAverageRef.current
+        if (!data || data.length === 0) return
+
+        // Get bars info for the visible range
+        const barsInfo = series.barsInLogicalRange(logicalRange)
+        if (!barsInfo) return
+
+        // Check if we need to load more historical data
+        // barsBefore tells us how many bars exist before the visible area
+        if (
+          barsInfo.barsBefore !== null &&
+          barsInfo.barsBefore < LAZY_LOAD_BARS_THRESHOLD &&
+          !isLoadingHistoricalRef.current
+        ) {
+          // User scrolled near the beginning - request more history
+          onNeedMoreHistoryRef.current?.()
+        }
+
+        // Check if the latest bar is visible
+        // The last bar is at logical index (data.length - 1)
+        // If logicalRange.to is greater than or equal to (data.length - 1), the latest bar is visible
+        const lastBarLogicalIndex = data.length - 1
+        const isLatestBarVisible = logicalRange.to >= lastBarLogicalIndex - 1 // -1 for some buffer
+
+        // Only notify if visibility changed
+        if (isLatestBarVisible !== lastLatestBarVisibleRef.current) {
+          lastLatestBarVisibleRef.current = isLatestBarVisible
+          onLatestBarVisibilityChangeRef.current?.(isLatestBarVisible)
+        }
+      }
+
+      // Subscribe to visible range changes
+      chart
+        .timeScale()
+        .subscribeVisibleLogicalRangeChange(handleVisibleLogicalRangeChange)
+
+      return () => {
+        chart
+          .timeScale()
+          .unsubscribeVisibleLogicalRangeChange(handleVisibleLogicalRangeChange)
+      }
+    }, []) // Empty deps - uses refs for callbacks to avoid re-subscribing
 
     // Update time range when it changes
     useEffect(() => {

--- a/apps/strength/tradingview/constants.ts
+++ b/apps/strength/tradingview/constants.ts
@@ -14,9 +14,10 @@ export const SCROLL_PAUSE_RESUME_MS = 300000 // 5 minutes (fallback)
 
 // Lazy loading thresholds
 // Number of bars before visible area that triggers loading more historical data
-export const LAZY_LOAD_BARS_THRESHOLD = 50
+export const LAZY_LOAD_BARS_THRESHOLD = 30
 // Number of minutes of historical data to fetch when lazy loading
-export const LAZY_LOAD_FETCH_MINUTES = 120 // 2 hours of data per load
+// At 1-minute intervals, 720 minutes = 720 data points = 12 hours of data
+export const LAZY_LOAD_FETCH_MINUTES = 720 // 12 hours of data per load
 
 export const SHOW_100_LINES = false
 

--- a/apps/strength/tradingview/constants.ts
+++ b/apps/strength/tradingview/constants.ts
@@ -18,6 +18,13 @@ export const LAZY_LOAD_BARS_THRESHOLD = 30
 // Number of hours of historical data to fetch when lazy loading
 // Should match FETCH_DATA_HOURS_BACK for consistent chunk sizes
 export const LAZY_LOAD_FETCH_HOURS = FETCH_DATA_HOURS_BACK // 240 hours = 10 days per load
+// Cooldown between lazy load requests (in ms)
+export const LAZY_LOAD_COOLDOWN_MS = 2000
+
+// Future padding - extend chart data into the future for visualization
+// This allows users to scroll into "future" time to see where the current trend might go
+export const FUTURE_PADDING_HOURS = 12
+export const FUTURE_PADDING_BARS = FUTURE_PADDING_HOURS * 60 // Convert to minutes (bars)
 
 export const SHOW_100_LINES = false
 

--- a/apps/strength/tradingview/constants.ts
+++ b/apps/strength/tradingview/constants.ts
@@ -15,9 +15,9 @@ export const SCROLL_PAUSE_RESUME_MS = 300000 // 5 minutes (fallback)
 // Lazy loading thresholds
 // Number of bars before visible area that triggers loading more historical data
 export const LAZY_LOAD_BARS_THRESHOLD = 30
-// Number of minutes of historical data to fetch when lazy loading
-// At 1-minute intervals, 720 minutes = 720 data points = 12 hours of data
-export const LAZY_LOAD_FETCH_MINUTES = 720 // 12 hours of data per load
+// Number of hours of historical data to fetch when lazy loading
+// Should match FETCH_DATA_HOURS_BACK for consistent chunk sizes
+export const LAZY_LOAD_FETCH_HOURS = FETCH_DATA_HOURS_BACK // 240 hours = 10 days per load
 
 export const SHOW_100_LINES = false
 

--- a/apps/strength/tradingview/constants.ts
+++ b/apps/strength/tradingview/constants.ts
@@ -9,7 +9,14 @@ export const FETCH_DATA_HOURS_BACK = 240
 export const FETCH_DATA_ROWS = 7250
 
 // Time in ms to wait after user stops scrolling before resuming polling
-export const SCROLL_PAUSE_RESUME_MS = 300000 // 30 seconds
+// Note: This is now less important as we use smart pause/resume based on visible range
+export const SCROLL_PAUSE_RESUME_MS = 300000 // 5 minutes (fallback)
+
+// Lazy loading thresholds
+// Number of bars before visible area that triggers loading more historical data
+export const LAZY_LOAD_BARS_THRESHOLD = 50
+// Number of minutes of historical data to fetch when lazy loading
+export const LAZY_LOAD_FETCH_MINUTES = 120 // 2 hours of data per load
 
 export const SHOW_100_LINES = false
 

--- a/apps/strength/tradingview/lib/data/AGENTS.md
+++ b/apps/strength/tradingview/lib/data/AGENTS.md
@@ -71,3 +71,37 @@ const MIN_FETCH_MINUTES = 4    // Minimum window
 const MAX_FETCH_MINUTES = 120  // Maximum window (2 hours)
 updateIntervalMs: 10000        // 10 seconds polling
 ```
+
+## Lazy Loading (Infinite History)
+
+The hook supports loading older historical data on demand:
+
+### New Return Values
+
+```typescript
+{
+  earliestDataTime: Date | null,    // Timestamp of first data point
+  latestDataTime: Date | null,      // Timestamp of last data point  
+  fetchHistoricalDataBefore: (beforeDate: Date, minutes: number) => Promise<void>,
+  isLoadingHistorical: boolean,     // Loading state for historical fetch
+}
+```
+
+### fetchHistoricalDataBefore
+
+Fetches data BEFORE the current earliest timestamp, used for lazy loading:
+
+```typescript
+// Fetch 120 minutes of data before the earliest point
+fetchHistoricalDataBefore(earliestDataTime, 120)
+```
+
+**Process:**
+1. Fetch from API: `fromDate = beforeDate - minutes`, `toDate = beforeDate`
+2. Merge with existing data (prepend to beginning)
+3. Update `earliestDataTimestampRef` and `earliestDataTime` state
+4. Triggers re-aggregation with the new historical data
+
+**Safeguards:**
+- Prevents duplicate concurrent fetches via `isFetchingHistoricalRef`
+- Exposes `isLoadingHistorical` for UI feedback and debouncing

--- a/apps/strength/tradingview/lib/data/useStrengthData.ts
+++ b/apps/strength/tradingview/lib/data/useStrengthData.ts
@@ -215,19 +215,12 @@ export function useStrengthData({
    */
   const fetchHistoricalDataBefore = useCallback(
     async (beforeDate: Date, minutes: number) => {
-      if (!isMountedRef.current) {
-        console.log('[useStrengthData] Component unmounted, skipping historical fetch')
-        return
-      }
-      
-      if (currentTickersRef.current.length === 0) {
-        console.log('[useStrengthData] No tickers selected, skipping historical fetch')
+      if (!isMountedRef.current || currentTickersRef.current.length === 0) {
         return
       }
 
       // Prevent duplicate concurrent fetches
       if (isFetchingHistoricalRef.current) {
-        console.log('[useStrengthData] Already fetching historical data, skipping')
         return
       }
 
@@ -239,26 +232,12 @@ export function useStrengthData({
         const toDate = new Date(beforeDate.getTime())
         const fromDate = new Date(toDate.getTime() - minutes * 60 * 1000)
 
-        console.log(
-          `[useStrengthData] Fetching historical data: ${fromDate.toISOString()} to ${toDate.toISOString()} (${minutes} minutes / ${Math.round(minutes/60)} hours)`
-        )
-
         const historicalTickerData =
           await FetchStrengthData.fetchMultipleTickersData(
             currentTickersRef.current,
             fromDate,
             toDate
           )
-
-        // Log what we received
-        console.log(`[useStrengthData] Received historical data for ${historicalTickerData.length} tickers:`, 
-          historicalTickerData.map((data, i) => ({
-            ticker: currentTickersRef.current[i],
-            rows: data?.length || 0,
-            firstTime: data?.[0]?.timenow?.toISOString(),
-            lastTime: data?.[data?.length - 1]?.timenow?.toISOString(),
-          }))
-        )
 
         if (!isMountedRef.current) {
           isFetchingHistoricalRef.current = false
@@ -269,21 +248,17 @@ export function useStrengthData({
         // Check if we actually got any data
         const totalRows = historicalTickerData.reduce((sum, data) => sum + (data?.length || 0), 0)
         if (totalRows === 0) {
-          console.log('[useStrengthData] No historical data returned from API')
           return
         }
 
         // Merge historical data with existing data (prepend to beginning)
         setRawData((prevData) => {
           let newEarliestTimestamp = earliestDataTimestampRef.current
-          
-          console.log(`[useStrengthData] Merging: prevData has ${prevData.length} tickers, earliest was ${earliestDataTimestampRef.current?.toISOString()}`)
 
           const mergedData = prevData.map((existingData, idx) => {
             const historicalData = historicalTickerData[idx]
             
             if (!historicalData || historicalData.length === 0) {
-              console.log(`[useStrengthData] Ticker ${idx}: No historical data to merge`)
               return existingData
             }
 
@@ -291,23 +266,16 @@ export function useStrengthData({
             const sortedHistorical = [...historicalData].sort(
               (a, b) => a.timenow.getTime() - b.timenow.getTime()
             )
-            
-            console.log(`[useStrengthData] Ticker ${idx}: Historical data range: ${sortedHistorical[0]?.timenow?.toISOString()} to ${sortedHistorical[sortedHistorical.length-1]?.timenow?.toISOString()} (${sortedHistorical.length} rows)`)
 
             // Merge with existing data
             if (!existingData) {
-              console.log(`[useStrengthData] Ticker ${idx}: No existing data, using historical only`)
               return sortedHistorical
             }
-            
-            console.log(`[useStrengthData] Ticker ${idx}: Existing data range: ${existingData[0]?.timenow?.toISOString()} to ${existingData[existingData.length-1]?.timenow?.toISOString()} (${existingData.length} rows)`)
 
             const merged = FetchStrengthData.mergeData(
               sortedHistorical,
               existingData
             )
-            
-            console.log(`[useStrengthData] Ticker ${idx}: After merge: ${merged[0]?.timenow?.toISOString()} to ${merged[merged.length-1]?.timenow?.toISOString()} (${merged.length} rows)`)
 
             // Track new earliest timestamp
             if (merged.length > 0) {
@@ -324,7 +292,6 @@ export function useStrengthData({
           })
 
           // Update earliest timestamp
-          console.log(`[useStrengthData] Updating earliest from ${earliestDataTimestampRef.current?.toISOString()} to ${newEarliestTimestamp?.toISOString()}`)
           earliestDataTimestampRef.current = newEarliestTimestamp
           if (newEarliestTimestamp) {
             setEarliestDataTime(newEarliestTimestamp)
@@ -332,15 +299,10 @@ export function useStrengthData({
 
           return mergedData
         })
-
-        console.log(
-          `[useStrengthData] Historical data fetched and merged. New earliest: ${earliestDataTimestampRef.current?.toISOString() || 'unknown'}`
-        )
       } catch (err) {
         console.error('[useStrengthData] Error fetching historical data:', err)
         // Don't set error state - keep showing existing data
       } finally {
-        console.log('[useStrengthData] Historical fetch complete, resetting loading state')
         isFetchingHistoricalRef.current = false
         setIsLoadingHistorical(false)
       }
@@ -366,13 +328,6 @@ export function useStrengthData({
       const fetchMinutes = calculateFetchWindow()
       const fromDate = new Date(now.getTime() - fetchMinutes * 60 * 1000)
       const toDate = now
-
-      // Log if we're fetching more than the minimum (indicates background tab recovery)
-      if (fetchMinutes > MIN_FETCH_MINUTES) {
-        console.log(
-          `[useStrengthData] Fetching ${fetchMinutes} minutes of data (background tab recovery)`
-        )
-      }
 
       const newTickerData = await FetchStrengthData.fetchMultipleTickersData(
         currentTickersRef.current,
@@ -488,9 +443,6 @@ export function useStrengthData({
         !paused
       ) {
         // Tab became visible - fetch immediately to fill any gaps
-        console.log(
-          '[useStrengthData] Tab visible - triggering immediate fetch'
-        )
         fetchRealtimeUpdate()
       }
     }
@@ -512,10 +464,8 @@ export function useStrengthData({
     if (paused) {
       // Stop polling while paused
       stopRealtimeUpdates()
-      console.log('[useStrengthData] Polling paused (user interaction)')
     } else {
       // Resume polling - fetch immediately to fill any gaps
-      console.log('[useStrengthData] Polling resumed - fetching missed data')
       fetchRealtimeUpdate()
       startRealtimeUpdates()
     }

--- a/apps/strength/tradingview/lib/data/useStrengthData.ts
+++ b/apps/strength/tradingview/lib/data/useStrengthData.ts
@@ -250,34 +250,64 @@ export function useStrengthData({
             toDate
           )
 
+        // Log what we received
+        console.log(`[useStrengthData] Received historical data for ${historicalTickerData.length} tickers:`, 
+          historicalTickerData.map((data, i) => ({
+            ticker: currentTickersRef.current[i],
+            rows: data?.length || 0,
+            firstTime: data?.[0]?.timenow?.toISOString(),
+            lastTime: data?.[data?.length - 1]?.timenow?.toISOString(),
+          }))
+        )
+
         if (!isMountedRef.current) {
           isFetchingHistoricalRef.current = false
           setIsLoadingHistorical(false)
           return
         }
 
+        // Check if we actually got any data
+        const totalRows = historicalTickerData.reduce((sum, data) => sum + (data?.length || 0), 0)
+        if (totalRows === 0) {
+          console.log('[useStrengthData] No historical data returned from API')
+          return
+        }
+
         // Merge historical data with existing data (prepend to beginning)
         setRawData((prevData) => {
           let newEarliestTimestamp = earliestDataTimestampRef.current
+          
+          console.log(`[useStrengthData] Merging: prevData has ${prevData.length} tickers, earliest was ${earliestDataTimestampRef.current?.toISOString()}`)
 
           const mergedData = prevData.map((existingData, idx) => {
             const historicalData = historicalTickerData[idx]
-            if (!historicalData || historicalData.length === 0) return existingData
+            
+            if (!historicalData || historicalData.length === 0) {
+              console.log(`[useStrengthData] Ticker ${idx}: No historical data to merge`)
+              return existingData
+            }
 
             // Sort historical data
             const sortedHistorical = [...historicalData].sort(
               (a, b) => a.timenow.getTime() - b.timenow.getTime()
             )
+            
+            console.log(`[useStrengthData] Ticker ${idx}: Historical data range: ${sortedHistorical[0]?.timenow?.toISOString()} to ${sortedHistorical[sortedHistorical.length-1]?.timenow?.toISOString()} (${sortedHistorical.length} rows)`)
 
             // Merge with existing data
             if (!existingData) {
+              console.log(`[useStrengthData] Ticker ${idx}: No existing data, using historical only`)
               return sortedHistorical
             }
+            
+            console.log(`[useStrengthData] Ticker ${idx}: Existing data range: ${existingData[0]?.timenow?.toISOString()} to ${existingData[existingData.length-1]?.timenow?.toISOString()} (${existingData.length} rows)`)
 
             const merged = FetchStrengthData.mergeData(
               sortedHistorical,
               existingData
             )
+            
+            console.log(`[useStrengthData] Ticker ${idx}: After merge: ${merged[0]?.timenow?.toISOString()} to ${merged[merged.length-1]?.timenow?.toISOString()} (${merged.length} rows)`)
 
             // Track new earliest timestamp
             if (merged.length > 0) {
@@ -294,6 +324,7 @@ export function useStrengthData({
           })
 
           // Update earliest timestamp
+          console.log(`[useStrengthData] Updating earliest from ${earliestDataTimestampRef.current?.toISOString()} to ${newEarliestTimestamp?.toISOString()}`)
           earliestDataTimestampRef.current = newEarliestTimestamp
           if (newEarliestTimestamp) {
             setEarliestDataTime(newEarliestTimestamp)

--- a/apps/strength/tradingview/lib/data/useStrengthData.ts
+++ b/apps/strength/tradingview/lib/data/useStrengthData.ts
@@ -46,6 +46,14 @@ export interface UseStrengthDataResult {
   lastUpdateTime: Date | null
   /** Key that changes when tickers change - use for chart reset */
   dataVersion: number
+  /** Timestamp of the earliest data point (for lazy loading detection) */
+  earliestDataTime: Date | null
+  /** Timestamp of the latest data point (for detecting if latest is visible) */
+  latestDataTime: Date | null
+  /** Fetch historical data going further back in time (for lazy loading) */
+  fetchHistoricalDataBefore: (beforeDate: Date, minutes: number) => Promise<void>
+  /** Whether historical data is currently being loaded */
+  isLoadingHistorical: boolean
 }
 
 /**
@@ -146,18 +154,23 @@ export function useStrengthData({
   const [error, setError] = useState<string | null>(null)
   const [lastUpdateTime, setLastUpdateTime] = useState<Date | null>(null)
   const [dataVersion, setDataVersion] = useState(0)
+  const [earliestDataTime, setEarliestDataTime] = useState<Date | null>(null)
+  const [latestDataTime, setLatestDataTime] = useState<Date | null>(null)
+  const [isLoadingHistorical, setIsLoadingHistorical] = useState(false)
 
   // Refs for tracking state
   const isMountedRef = useRef(true)
   const updateIntervalRef = useRef<NodeJS.Timeout | null>(null)
   const currentTickersRef = useRef<string[]>([])
   const lastDataTimestampRef = useRef<Date | null>(null)
+  const earliestDataTimestampRef = useRef<Date | null>(null)
 
   // Track last successful fetch time for calculating dynamic window
   const lastSuccessfulFetchRef = useRef<Date | null>(null)
 
   // Track if we're currently fetching to prevent duplicate requests
   const isFetchingRef = useRef(false)
+  const isFetchingHistoricalRef = useRef(false)
 
   /**
    * Stop real-time updates
@@ -192,6 +205,106 @@ export function useStrengthData({
     // Cap at maximum
     return Math.min(fetchMinutes, MAX_FETCH_MINUTES)
   }, [])
+
+  /**
+   * Fetch historical data going further back in time (for lazy loading)
+   * This fetches data BEFORE the current earliest data point
+   *
+   * @param beforeDate - Fetch data before this date
+   * @param minutes - Number of minutes of data to fetch
+   */
+  const fetchHistoricalDataBefore = useCallback(
+    async (beforeDate: Date, minutes: number) => {
+      if (!isMountedRef.current || currentTickersRef.current.length === 0) return
+
+      // Prevent duplicate concurrent fetches
+      if (isFetchingHistoricalRef.current) {
+        console.log('[useStrengthData] Already fetching historical data, skipping')
+        return
+      }
+
+      isFetchingHistoricalRef.current = true
+      setIsLoadingHistorical(true)
+
+      try {
+        // Calculate the time range to fetch
+        const toDate = new Date(beforeDate.getTime())
+        const fromDate = new Date(toDate.getTime() - minutes * 60 * 1000)
+
+        console.log(
+          `[useStrengthData] Fetching historical data: ${fromDate.toISOString()} to ${toDate.toISOString()} (${minutes} minutes)`
+        )
+
+        const historicalTickerData =
+          await FetchStrengthData.fetchMultipleTickersData(
+            currentTickersRef.current,
+            fromDate,
+            toDate
+          )
+
+        if (!isMountedRef.current) {
+          isFetchingHistoricalRef.current = false
+          setIsLoadingHistorical(false)
+          return
+        }
+
+        // Merge historical data with existing data (prepend to beginning)
+        setRawData((prevData) => {
+          let newEarliestTimestamp = earliestDataTimestampRef.current
+
+          const mergedData = prevData.map((existingData, idx) => {
+            const historicalData = historicalTickerData[idx]
+            if (!historicalData || historicalData.length === 0) return existingData
+
+            // Sort historical data
+            const sortedHistorical = [...historicalData].sort(
+              (a, b) => a.timenow.getTime() - b.timenow.getTime()
+            )
+
+            // Merge with existing data
+            if (!existingData) {
+              return sortedHistorical
+            }
+
+            const merged = FetchStrengthData.mergeData(
+              sortedHistorical,
+              existingData
+            )
+
+            // Track new earliest timestamp
+            if (merged.length > 0) {
+              const first = merged[0]
+              if (
+                first &&
+                (!newEarliestTimestamp || first.timenow < newEarliestTimestamp)
+              ) {
+                newEarliestTimestamp = first.timenow
+              }
+            }
+
+            return merged
+          })
+
+          // Update earliest timestamp
+          earliestDataTimestampRef.current = newEarliestTimestamp
+          if (newEarliestTimestamp) {
+            setEarliestDataTime(newEarliestTimestamp)
+          }
+
+          return mergedData
+        })
+
+        console.log('[useStrengthData] Historical data fetched and merged')
+      } catch (err) {
+        console.error('Error fetching historical data:', err)
+        // Don't set error state - keep showing existing data
+      } finally {
+        isFetchingHistoricalRef.current = false
+        setIsLoadingHistorical(false)
+      }
+    },
+    []
+  )
 
   /**
    * Fetch real-time update with dynamic window based on time since last fetch
@@ -291,6 +404,10 @@ export function useStrengthData({
         })
 
         lastDataTimestampRef.current = newLatestTimestamp
+        // Update the latest data time state for external consumers
+        if (newLatestTimestamp) {
+          setLatestDataTime(newLatestTimestamp)
+        }
         return mergedData
       })
 
@@ -412,11 +529,16 @@ export function useStrengthData({
           return
         }
 
-        // Find latest timestamp
+        // Find earliest and latest timestamps
         let latestTimestamp: Date | null = null
+        let earliestTimestamp: Date | null = null
         allTickerData.forEach((tickerData) => {
           if (tickerData && tickerData.length > 0) {
+            const first = tickerData[0]
             const last = tickerData[tickerData.length - 1]
+            if (first && (!earliestTimestamp || first.timenow < earliestTimestamp)) {
+              earliestTimestamp = first.timenow
+            }
             if (last && (!latestTimestamp || last.timenow > latestTimestamp)) {
               latestTimestamp = last.timenow
             }
@@ -425,8 +547,11 @@ export function useStrengthData({
 
         setRawData(allTickerData)
         lastDataTimestampRef.current = latestTimestamp
+        earliestDataTimestampRef.current = earliestTimestamp
         lastSuccessfulFetchRef.current = new Date()
         setLastUpdateTime(new Date())
+        setEarliestDataTime(earliestTimestamp)
+        setLatestDataTime(latestTimestamp)
         setDataState('ready')
 
         // Start real-time updates
@@ -486,5 +611,9 @@ export function useStrengthData({
     error,
     lastUpdateTime,
     dataVersion,
+    earliestDataTime,
+    latestDataTime,
+    fetchHistoricalDataBefore,
+    isLoadingHistorical,
   }
 }

--- a/apps/strength/tradingview/lib/data/useStrengthData.ts
+++ b/apps/strength/tradingview/lib/data/useStrengthData.ts
@@ -215,7 +215,15 @@ export function useStrengthData({
    */
   const fetchHistoricalDataBefore = useCallback(
     async (beforeDate: Date, minutes: number) => {
-      if (!isMountedRef.current || currentTickersRef.current.length === 0) return
+      if (!isMountedRef.current) {
+        console.log('[useStrengthData] Component unmounted, skipping historical fetch')
+        return
+      }
+      
+      if (currentTickersRef.current.length === 0) {
+        console.log('[useStrengthData] No tickers selected, skipping historical fetch')
+        return
+      }
 
       // Prevent duplicate concurrent fetches
       if (isFetchingHistoricalRef.current) {
@@ -232,7 +240,7 @@ export function useStrengthData({
         const fromDate = new Date(toDate.getTime() - minutes * 60 * 1000)
 
         console.log(
-          `[useStrengthData] Fetching historical data: ${fromDate.toISOString()} to ${toDate.toISOString()} (${minutes} minutes)`
+          `[useStrengthData] Fetching historical data: ${fromDate.toISOString()} to ${toDate.toISOString()} (${minutes} minutes / ${Math.round(minutes/60)} hours)`
         )
 
         const historicalTickerData =
@@ -294,11 +302,14 @@ export function useStrengthData({
           return mergedData
         })
 
-        console.log('[useStrengthData] Historical data fetched and merged')
+        console.log(
+          `[useStrengthData] Historical data fetched and merged. New earliest: ${earliestDataTimestampRef.current?.toISOString() || 'unknown'}`
+        )
       } catch (err) {
-        console.error('Error fetching historical data:', err)
+        console.error('[useStrengthData] Error fetching historical data:', err)
         // Don't set error state - keep showing existing data
       } finally {
+        console.log('[useStrengthData] Historical fetch complete, resetting loading state')
         isFetchingHistoricalRef.current = false
         setIsLoadingHistorical(false)
       }

--- a/apps/strength/tradingview/lib/workers/useAggregationWorker.ts
+++ b/apps/strength/tradingview/lib/workers/useAggregationWorker.ts
@@ -168,9 +168,6 @@ export function useAggregationWorker(
 
         // Check if this result is stale (from an older data version)
         if (dataVersion < validDataVersionRef.current) {
-          console.log(
-            `[Worker] Ignoring stale result (dataVersion: ${dataVersion}, valid: ${validDataVersionRef.current})`
-          )
           return
         }
 

--- a/lib/common/sql/strength/gets.ts
+++ b/lib/common/sql/strength/gets.ts
@@ -24,6 +24,7 @@ type Props = {
     node_env?: string;
     limit?: number;
     timenow_gt?: Date | string; // Greater than or equal to (on or after)
+    timenow_lt?: Date | string; // Less than (before)
   };
 };
 
@@ -31,7 +32,8 @@ type Props = {
  * This utility function fetches data from the strength_v1 table, allowing the component calling it to specify parameters for WHERE to filter the results.
  *
  * Supports date range filtering on timenow column:
- * - timenow_gt: Get records on or after this date
+ * - timenow_gt: Get records on or after this date (>=)
+ * - timenow_lt: Get records before this date (<) - used for lazy loading historical data
  *
  * Date parameters accept Date objects or ISO string timestamps.
  */
@@ -65,10 +67,16 @@ export const strengthGets = async function ({ where }: Props = {}): Promise<Outp
       whereClauses.push(`node_env = $${params.length}`);
     }
 
-    // Starting time
+    // Starting time (on or after)
     if (where?.timenow_gt) {
       params.push(where.timenow_gt);
       whereClauses.push(`timenow >= $${params.length}`);
+    }
+    
+    // Ending time (before) - used for lazy loading historical data
+    if (where?.timenow_lt) {
+      params.push(where.timenow_lt);
+      whereClauses.push(`timenow < $${params.length}`);
     }
 
     if (whereClauses.length > 0) {


### PR DESCRIPTION
Implement lazy loading for historical chart data and smart pause/resume for real-time updates to enable infinite scrolling and prevent chart jumps.

The previous chart implementation would auto-scroll to the latest real-time data upon updates, making it impossible to view historical data without the chart jumping. This PR introduces lazy loading to fetch older data as the user scrolls back, preserving the visible date range. It also intelligently pauses real-time updates when the user is viewing historical data and resumes, fetching all missed data, when the user scrolls back to the present.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b4d053b-5b27-471b-a438-6960302de4a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3b4d053b-5b27-471b-a438-6960302de4a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core chart interaction behavior (polling pause/resume, time-range handling, scroll restoration) and expands the data-fetch/query surface with a new upper-bound timestamp filter.
> 
> **Overview**
> Enables *infinite scroll* for chart history: the `/api/v1/strength` endpoint and `strengthGets` now accept `timenow_lt` so clients can request bounded windows for backfilling older data.
> 
> Updates the TradingView chart flow to lazy-load older history when the user nears the left edge, prepend/merge the fetched data, and preserve the user’s view by restoring the visible logical range after prepends; it also adds a loading overlay during historical fetches.
> 
> Reworks real-time behavior to **pause polling when the latest bar isn’t visible** (user scrolled back) and resume when it is, while avoiding time-range/zoom resets during realtime updates or historical loads.
> 
> Adds a standalone `/historical` demo page with a minimal `SimpleChart` implementation to validate lazy loading + scroll preservation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23938f49f023adc1151d5fe6f73959cfdd2558e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->