### PR TITLE
Continuous VWAP calculation

### DIFF
--- a/apps/market-write-node/AGENTS.md
+++ b/apps/market-write-node/AGENTS.md
@@ -22,7 +22,8 @@ second:
 - output timeframe: 1 minute
 - output write cadence: 1 second
 - short no-trade gaps are forward-filled as zero-volume seconds
-- extended inactivity resets the rolling warmup instead of stitching distant seconds together
+- extended open-market inactivity resets the rolling warmup instead of stitching distant seconds together
+- scheduled daily/weekend market closures should be treated as paused time so rolling VWAP/CVD continuity carries across the close and reopen
 
 Each `candles_1h_1m` row is the trailing 60-minute window for a ticker at that
 minute:

--- a/apps/market-write-node/README.md
+++ b/apps/market-write-node/README.md
@@ -10,8 +10,9 @@ This app maintains:
 
 The shared rolling engine forward-fills short no-trade gaps as zero-volume
 seconds so minute-boundary rows stay available for the hourly layer. Extended
-gaps reset warmup instead of combining distant activity into one "continuous"
-window.
+open-market gaps reset warmup instead of combining distant activity into one
+"continuous" window, but scheduled daily/weekend closures are treated as
+paused time so rolling VWAP/CVD continuity carries across the close and reopen.
 
 ## What this app does
 

--- a/apps/market-write-node/docs/data-storage/candles-schema.md
+++ b/apps/market-write-node/docs/data-storage/candles-schema.md
@@ -33,8 +33,10 @@ Each row is:
 - the trailing 60-second rolling window ending at that second
 
 The shared 1m engine forward-fills short no-trade gaps as zero-volume seconds so
-minute-boundary rows remain available for the hourly layer. Extended inactivity
-resets warmup instead of stitching distant seconds into one continuous window.
+minute-boundary rows remain available for the hourly layer. Extended
+open-market inactivity resets warmup instead of stitching distant seconds into
+one continuous window, but scheduled market closures are skipped so rolling
+windows remain continuous across the close and reopen.
 
 ### `candles_1h_1m`
 

--- a/apps/market-write-node/src/lib/trade/index.ts
+++ b/apps/market-write-node/src/lib/trade/index.ts
@@ -33,6 +33,9 @@ export {
   checkTradeAge,
 } from "./timestamp.js";
 
+// Market-hours utilities
+export { collectOpenBucketTimesBetween, isFuturesMarketOpenAt } from "./market-hours.js";
+
 // Symbol utilities
 export { extractTicker } from "./symbol.js";
 

--- a/apps/market-write-node/src/lib/trade/market-hours.ts
+++ b/apps/market-write-node/src/lib/trade/market-hours.ts
@@ -1,0 +1,115 @@
+/**
+ * Futures market-hours helpers shared by live and batch aggregation.
+ *
+ * The rolling candle windows should treat scheduled market closures as paused
+ * time rather than as a gap that forces VWAP/CVD continuity to reset.
+ */
+
+export interface OpenBucketCollection {
+  bucketTimes: number[];
+  openBucketCount: number;
+  exceeded: boolean;
+}
+
+/**
+ * CME-style futures market hours in UTC:
+ * - Mon-Thu: closed 22:00-22:59
+ * - Fri: closed from 22:00 through the weekend
+ * - Sat: closed all day
+ * - Sun: opens at 23:00
+ */
+export function isFuturesMarketOpenAt(date: Date): boolean {
+  const utcDay = date.getUTCDay(); // 0 = Sunday, 5 = Friday, 6 = Saturday
+  const utcHour = date.getUTCHours();
+
+  if (utcDay === 6) {
+    return false;
+  }
+
+  if (utcDay === 0 && utcHour < 23) {
+    return false;
+  }
+
+  if (utcDay === 5 && utcHour >= 22) {
+    return false;
+  }
+
+  if (utcHour === 22) {
+    return false;
+  }
+
+  return true;
+}
+
+function getNextFuturesMarketOpenMs(currentMs: number): number {
+  const date = new Date(currentMs);
+  const utcDay = date.getUTCDay();
+  const utcHour = date.getUTCHours();
+
+  if (utcDay === 6) {
+    date.setUTCDate(date.getUTCDate() + 1);
+    date.setUTCHours(23, 0, 0, 0);
+    return date.getTime();
+  }
+
+  if (utcDay === 0 && utcHour < 23) {
+    date.setUTCHours(23, 0, 0, 0);
+    return date.getTime();
+  }
+
+  if (utcDay === 5 && utcHour >= 22) {
+    date.setUTCDate(date.getUTCDate() + 2);
+    date.setUTCHours(23, 0, 0, 0);
+    return date.getTime();
+  }
+
+  if (utcHour === 22) {
+    date.setUTCHours(23, 0, 0, 0);
+    return date.getTime();
+  }
+
+  return currentMs;
+}
+
+/**
+ * Collect missing open-market buckets between two timestamps.
+ *
+ * Closed-market spans are skipped entirely so scheduled daily/weekend closures
+ * do not count against gap-reset limits.
+ */
+export function collectOpenBucketTimesBetween(
+  startMsInclusive: number,
+  endMsExclusive: number,
+  stepMs: number,
+  maxOpenBuckets: number,
+): OpenBucketCollection {
+  const bucketTimes: number[] = [];
+  let openBucketCount = 0;
+  let currentMs = startMsInclusive;
+
+  while (currentMs < endMsExclusive) {
+    if (!isFuturesMarketOpenAt(new Date(currentMs))) {
+      const nextOpenMs = getNextFuturesMarketOpenMs(currentMs);
+      currentMs = nextOpenMs > currentMs ? nextOpenMs : currentMs + stepMs;
+      continue;
+    }
+
+    openBucketCount++;
+    if (openBucketCount > maxOpenBuckets) {
+      return {
+        bucketTimes,
+        openBucketCount,
+        exceeded: true,
+      };
+    }
+
+    bucketTimes.push(currentMs);
+    currentMs += stepMs;
+  }
+
+  return {
+    bucketTimes,
+    openBucketCount,
+    exceeded: false,
+  };
+}

--- a/apps/market-write-node/src/lib/trade/rolling-candle-window.ts
+++ b/apps/market-write-node/src/lib/trade/rolling-candle-window.ts
@@ -3,6 +3,7 @@
  * already-finalized lower-timeframe candle rows.
  */
 
+import { collectOpenBucketTimesBetween } from "./market-hours.js";
 import type { CandleForDb, CandleState } from "./types.js";
 
 interface TickerWindowState {
@@ -37,7 +38,6 @@ export class RollingCandleWindow {
   private readonly tickerStates = new Map<string, TickerWindowState>();
   private readonly windowSize: number;
   private readonly expectedIntervalMs: number;
-  private readonly windowSpanMs: number;
   private readonly label: string;
 
   private pendingCandles: CandleForDb[] = [];
@@ -51,7 +51,6 @@ export class RollingCandleWindow {
   constructor(options: RollingCandleWindowOptions) {
     this.windowSize = options.windowSize;
     this.expectedIntervalMs = options.expectedIntervalMs;
-    this.windowSpanMs = (this.windowSize - 1) * this.expectedIntervalMs;
     this.label = options.label;
   }
 
@@ -139,9 +138,13 @@ export class RollingCandleWindow {
       }
 
       if (deltaMs > this.expectedIntervalMs) {
-        state.ring = [];
-        state.warmupDone = false;
-        this.stats.gapResets++;
+        const firstMissingInputMs = state.lastInputMs + this.expectedIntervalMs;
+        const openGap = collectOpenBucketTimesBetween(firstMissingInputMs, inputTimeMs, this.expectedIntervalMs, 0);
+        if (openGap.exceeded) {
+          state.ring = [];
+          state.warmupDone = false;
+          this.stats.gapResets++;
+        }
       }
     }
 
@@ -149,8 +152,7 @@ export class RollingCandleWindow {
     state.lastInputMs = inputTimeMs;
     state.ring.push(input);
 
-    const cutoffMs = inputTimeMs - this.windowSpanMs;
-    while (state.ring.length > 0 && new Date(state.ring[0].time).getTime() < cutoffMs) {
+    while (state.ring.length > this.windowSize) {
       state.ring.shift();
     }
 

--- a/apps/market-write-node/src/lib/trade/rolling-vwap-continuity.test.ts
+++ b/apps/market-write-node/src/lib/trade/rolling-vwap-continuity.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { RollingCandleWindow } from "./rolling-candle-window.js";
+import { RollingWindow1m } from "./rolling-window.js";
+import type { CandleForDb, CandleState, NormalizedTrade } from "./types.js";
+
+function makeTrade(symbol: string, price: number): NormalizedTrade {
+  return {
+    ticker: "ES",
+    symbol,
+    price,
+    size: 1,
+    isAsk: true,
+    isBid: false,
+    bidPrice: price - 0.25,
+    askPrice: price + 0.25,
+    bidSize: 10,
+    askSize: 10,
+  };
+}
+
+function addTrade(window: RollingWindow1m, symbol: string, isoTime: string, price: number): void {
+  window.addTrade({
+    trade: makeTrade(symbol, price),
+    secondBucket: isoTime,
+    minuteBucket: isoTime.slice(0, 16) + ":00.000Z",
+  });
+}
+
+function makeCandleForDb(time: string, price: number): CandleForDb {
+  const candle: CandleState = {
+    open: price,
+    high: price,
+    low: price,
+    close: price,
+    volume: 1,
+    askVolume: 1,
+    bidVolume: 0,
+    unknownSideVolume: 0,
+    sumBidDepth: 10,
+    sumAskDepth: 10,
+    sumSpread: 0,
+    sumMidPrice: price,
+    sumPriceVolume: price,
+    maxTradeSize: 1,
+    largeTradeCount: 0,
+    largeTradeVolume: 0,
+    tradeCount: 1,
+    symbol: "ESH6",
+    currentCvd: 1,
+    metricsOHLC: {
+      cvd: {
+        open: 1,
+        high: 1,
+        low: 1,
+        close: 1,
+      },
+    },
+  };
+
+  return {
+    key: `ES|${time}`,
+    ticker: "ES",
+    time,
+    candle,
+  };
+}
+
+test("1m rolling VWAP accumulator stays continuous across the daily close", () => {
+  const window = new RollingWindow1m({
+    windowSeconds: 3,
+    maxSyntheticGapSeconds: 5,
+  });
+
+  addTrade(window, "ESH6", "2026-03-09T21:59:57.000Z", 100);
+  addTrade(window, "ESH6", "2026-03-09T21:59:58.000Z", 101);
+  addTrade(window, "ESH6", "2026-03-09T21:59:59.000Z", 102);
+  addTrade(window, "ESH6", "2026-03-09T23:00:00.000Z", 103);
+  window.finalizeAll();
+
+  const candles = window.drainPendingCandles();
+  const reopenCandle = candles.at(-1);
+
+  assert.ok(reopenCandle);
+  assert.equal(reopenCandle.time, "2026-03-09T23:00:00.000Z");
+  assert.equal(reopenCandle.candle.volume, 3);
+  assert.equal(reopenCandle.candle.sumPriceVolume, 306);
+  assert.equal(reopenCandle.candle.open, 101);
+  assert.equal(reopenCandle.candle.close, 103);
+  assert.equal(window.getStats().gapResets, 0);
+});
+
+test("1h rolling VWAP accumulator stays continuous across the daily close", () => {
+  const window = new RollingCandleWindow({
+    windowSize: 3,
+    expectedIntervalMs: 60_000,
+    label: "1h@1m",
+  });
+
+  window.addCandles([
+    makeCandleForDb("2026-03-09T21:57:00.000Z", 100),
+    makeCandleForDb("2026-03-09T21:58:00.000Z", 101),
+    makeCandleForDb("2026-03-09T21:59:00.000Z", 102),
+    makeCandleForDb("2026-03-09T23:00:00.000Z", 103),
+  ]);
+
+  const candles = window.drainPendingCandles();
+  const reopenCandle = candles.at(-1);
+
+  assert.ok(reopenCandle);
+  assert.equal(reopenCandle.time, "2026-03-09T23:00:00.000Z");
+  assert.equal(reopenCandle.candle.volume, 3);
+  assert.equal(reopenCandle.candle.sumPriceVolume, 306);
+  assert.equal(reopenCandle.candle.open, 101);
+  assert.equal(reopenCandle.candle.close, 103);
+  assert.equal(window.getStats().gapResets, 0);
+});

--- a/apps/market-write-node/src/lib/trade/rolling-window.ts
+++ b/apps/market-write-node/src/lib/trade/rolling-window.ts
@@ -8,6 +8,7 @@
 
 import { createCandleFromTrade, updateCandleCvdOHLC, updateCandleWithTrade } from "./candle-aggregation.js";
 import { FrontMonthTracker } from "./front-month.js";
+import { collectOpenBucketTimesBetween } from "./market-hours.js";
 import type { CandleForDb, CandleState, MetricCalculationContext, NormalizedTrade } from "./types.js";
 
 interface SecondSummary {
@@ -81,7 +82,6 @@ export class RollingWindow1m {
   private readonly tickerStates = new Map<string, TickerRollingState>();
   private readonly tracker: FrontMonthTracker;
   private readonly windowSeconds: number;
-  private readonly windowSpanMs: number;
   private readonly maxSyntheticGapSeconds: number;
 
   private pendingCandles: CandleForDb[] = [];
@@ -93,7 +93,6 @@ export class RollingWindow1m {
 
   constructor(options?: { windowSeconds?: number; maxSyntheticGapSeconds?: number; tracker?: FrontMonthTracker }) {
     this.windowSeconds = options?.windowSeconds ?? DEFAULT_WINDOW_SECONDS;
-    this.windowSpanMs = (this.windowSeconds - 1) * 1000;
     this.maxSyntheticGapSeconds = options?.maxSyntheticGapSeconds ?? DEFAULT_MAX_SYNTHETIC_GAP_SECONDS;
     this.tracker = options?.tracker ?? new FrontMonthTracker();
   }
@@ -370,13 +369,18 @@ export class RollingWindow1m {
       return;
     }
 
-    const missingSeconds = Math.floor((targetSecondMsExclusive - firstMissingSecondMs) / 1000);
-    if (missingSeconds > this.maxSyntheticGapSeconds) {
-      this.resetTickerGapState(ticker, state, missingSeconds);
+    const openGap = collectOpenBucketTimesBetween(
+      firstMissingSecondMs,
+      targetSecondMsExclusive,
+      1000,
+      this.maxSyntheticGapSeconds,
+    );
+    if (openGap.exceeded) {
+      this.resetTickerGapState(ticker, state, openGap.openBucketCount);
       return;
     }
 
-    for (let timeMs = firstMissingSecondMs; timeMs < targetSecondMsExclusive; timeMs += 1000) {
+    for (const timeMs of openGap.bucketTimes) {
       const summary = this.createSyntheticSecondSummary(state.lastSummary, timeMs);
       this.syntheticSecondsFilled++;
       this.processCompletedSummary(ticker, state, summary);
@@ -422,13 +426,8 @@ export class RollingWindow1m {
     this.secondsProcessed++;
     state.warmupSecondsCollected++;
 
-    const cutoffMs = summary.timeMs - this.windowSpanMs;
-    let pruneIdx = 0;
-    while (pruneIdx < state.ring.length && state.ring[pruneIdx].timeMs < cutoffMs) {
-      pruneIdx++;
-    }
-    if (pruneIdx > 0) {
-      state.ring = state.ring.slice(pruneIdx);
+    while (state.ring.length > this.windowSeconds) {
+      state.ring.shift();
     }
 
     if (state.ring.length === 0) {
@@ -457,7 +456,7 @@ export class RollingWindow1m {
     });
   }
 
-  private resetTickerGapState(ticker: string, state: TickerRollingState, missingSeconds: number): void {
+  private resetTickerGapState(ticker: string, state: TickerRollingState, missingOpenSeconds: number): void {
     state.ring = [];
     state.currentCandle = null;
     state.currentSecondBucket = null;
@@ -466,7 +465,7 @@ export class RollingWindow1m {
     state.lastSummary = null;
     this.gapResets++;
     console.log(
-      `⏭️ Reset rolling 1m state for ${ticker} after ${missingSeconds}s gap ` +
+      `⏭️ Reset rolling 1m state for ${ticker} after ${missingOpenSeconds}s open-market gap ` +
         `(max synthetic fill ${this.maxSyntheticGapSeconds}s)`,
     );
   }

--- a/apps/market-write-node/src/stream/tbbo-stream.ts
+++ b/apps/market-write-node/src/stream/tbbo-stream.ts
@@ -10,6 +10,7 @@
 
 import { createConnection, Socket } from "net";
 import { createHash } from "crypto";
+import { isFuturesMarketOpenAt } from "../lib/trade/index.js";
 import { Tbbo1mAggregator, TbboRecord } from "./tbbo-1m-aggregator.js";
 
 // Configuration from environment (all required - no defaults)
@@ -25,43 +26,8 @@ const DATABENTO_STYPE = process.env.DATABENTO_STYPE;
 const MAX_RECONNECT_DELAY = 30000;
 const INITIAL_RECONNECT_DELAY = 1000;
 
-/**
- * Check if futures market is currently open
- *
- * Futures market closed hours (all times in UTC):
- * - All days: 22:00 - 22:59 (daily maintenance window)
- * - Friday: 22:00 - 24:00 (weekend close starts)
- * - Saturday: all day (closed)
- * - Sunday: 0:00 - 22:59 (closed until market opens at 23:00)
- *
- * @returns true if market is open, false if closed
- */
 function isFuturesMarketOpen(): boolean {
-  const now = new Date();
-  const utcDay = now.getUTCDay(); // 0 = Sunday, 5 = Friday, 6 = Saturday
-  const utcHour = now.getUTCHours();
-
-  // Saturday: all day closed
-  if (utcDay === 6) {
-    return false;
-  }
-
-  // Sunday: closed 0:00 - 22:59, opens at 23:00
-  if (utcDay === 0 && utcHour < 23) {
-    return false;
-  }
-
-  // Friday: closed from 22:00 onward (until Sunday 23:00)
-  if (utcDay === 5 && utcHour >= 22) {
-    return false;
-  }
-
-  // All other days (Mon-Thu, and Sun after 23:00): closed 22:00 - 22:59
-  if (utcHour === 22) {
-    return false;
-  }
-
-  return true;
+  return isFuturesMarketOpenAt(new Date());
 }
 
 // Track skipped records due to market closed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Preserve VWAP continuity for 1m and 1h candles across scheduled market closures.

The previous implementation treated scheduled market closures (e.g., overnight, weekends) as periods of inactivity, causing the rolling VWAP accumulators to reset or prune prior state. This PR modifies the rolling window logic to treat these periods as paused time, ensuring that VWAP calculations for 1m and 1h candles continue seamlessly from the last open market period to the next.

---
<p><a href="https://cursor.com/agents/bc-62a8dd8f-92b3-4d78-87ce-af94c999ec72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62a8dd8f-92b3-4d78-87ce-af94c999ec72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->