### PR TITLE
Update DB migration documentation

### DIFF
--- a/apps/market-write-node/AGENTS.md
+++ b/apps/market-write-node/AGENTS.md
@@ -89,6 +89,11 @@ Key rules:
 - keep column contracts aligned with `@lib/db-timescale` migrations, schema snapshot, and generated types
 - `price_pct` is stored in basis points, not percent
 - `sum_price_volume` is the stored VWAP accumulator; there is no canonical per-row `vwap` column
+- do not create or alter Timescale tables manually; change `@lib/db-timescale/migrations`
+- fresh empty DB: run `db:migrate`, not `db:migrate:baseline`
+- existing pre-migration DB with baseline schema already present: run `db:migrate:baseline` once, then `db:migrate`
+- after DB contract changes, run `pnpm --filter @lib/db-timescale db:verify`
+- if a migration must change populated data, the migration SQL must backfill or convert existing rows explicitly
 
 ## Source layout
 

--- a/apps/market-write-node/README.md
+++ b/apps/market-write-node/README.md
@@ -28,6 +28,65 @@ It should:
 
 It should not own downstream feature engineering or ML workflows.
 
+## Database ownership and setup
+
+This app does not own database migrations directly.
+
+- `@lib/db-timescale` owns the `TIMESCALE_URL` schema contract
+- `market-write-node` depends on that package for canonical candle tables
+
+### Fresh empty Timescale database
+
+Use this path for a new environment with no existing tables:
+
+```bash
+export TIMESCALE_URL="postgres://..."
+pnpm --filter @lib/db-timescale db:migrate
+pnpm --filter @lib/db-timescale db:verify
+```
+
+What this does:
+
+- creates the baseline candle tables
+- applies forward migrations such as:
+  - `candles_1h_1m`
+  - `candles_1m_1s` contract cleanup
+  - Timescale hypertable/compression setup
+- verifies that `schema/current.sql` and generated DB artifacts still match the
+  migrated database
+
+### Existing database that already has the baseline schema
+
+Use this path only if the database already contains the baseline tables from a
+manual or legacy setup:
+
+```bash
+export TIMESCALE_URL="postgres://..."
+pnpm --filter @lib/db-timescale db:migrate:baseline
+pnpm --filter @lib/db-timescale db:migrate
+pnpm --filter @lib/db-timescale db:verify
+```
+
+Do **not** use `db:migrate:baseline` for a fresh empty database.
+
+### Existing populated tables with schema changes
+
+The migration runner supports in-place upgrades, but the migration SQL must
+define how existing data is handled.
+
+Examples:
+
+- new column on populated table:
+  1. add nullable column or safe default
+  2. backfill with `UPDATE`
+  3. add `NOT NULL` or other strict constraint
+- type change:
+  - use `ALTER COLUMN ... TYPE ... USING ...` so existing rows are converted
+
+If a future migration cannot safely transform existing data by SQL alone, the
+migration file must document the extra manual or application-side step. That is
+the exception, not the default.
+
 ## Database setup
 
 This app uses the `TIMESCALE_URL` database owned by `@lib/db-timescale`.
@@ -41,7 +100,8 @@ export TIMESCALE_URL="postgres://..."
 ```
 
 The target database must support the TimescaleDB APIs used by the migrations,
-including hypertables and compression policies.
+including hypertables and compression policies. The DB role must be allowed to
+create the `timescaledb` extension.
 
 ### 2. Apply the DB migration
 
@@ -49,6 +109,7 @@ From the repo root:
 
 ```bash
 pnpm --filter @lib/db-timescale db:migrate
+pnpm --filter @lib/db-timescale db:verify
 ```
 
 This must create/update:
@@ -57,6 +118,9 @@ This must create/update:
 - `candles_1h_1m`
 
 ### 3. Refresh schema snapshot and generated DB artifacts
+
+Only do this when you are maintaining the DB package itself and intend to commit
+updated DB artifacts.
 
 After the migration has been applied to the target database, refresh the DB
 contract artifacts:
@@ -70,6 +134,13 @@ Or run both after migration:
 
 ```bash
 pnpm --filter @lib/db-timescale db:sync
+```
+
+For normal deploy/bootstrap work, prefer:
+
+```bash
+pnpm --filter @lib/db-timescale db:migrate
+pnpm --filter @lib/db-timescale db:verify
 ```
 
 ## Historical rebuild flow
@@ -91,6 +162,8 @@ Notes:
 - `historical:1h1m` reads only minute-boundary rows from `candles_1m_1s`
 - `--truncate` is recommended for a full deterministic rebuild
 - without `--truncate`, the script upserts into `candles_1h_1m`
+- if you intentionally start from an empty DB, run the DB migrations first, then
+  rebuild `candles_1m_1s`, then rebuild `candles_1h_1m`
 
 ## Live flow
 
@@ -127,6 +200,14 @@ warmup.
 - keep historical and live behavior aligned through shared library code
 - `price_pct` is stored in basis points
 - `sum_price_volume / volume` is the query-time VWAP formula
+- do not manually create or alter Timescale tables; make schema changes in
+  `@lib/db-timescale/migrations`
+- after schema changes, run `pnpm --filter @lib/db-timescale db:verify`
+
+## Related docs
+
+- `lib/db-timescale/README.md` - DB package setup and migration workflow
+- `docs/db/management-playbook.md` - repo-wide migration patterns
 
 ## Validation
 

--- a/lib/db-postgres/AGENTS.md
+++ b/lib/db-postgres/AGENTS.md
@@ -18,3 +18,9 @@ Database-first package for the `POSTGRES_URL` database.
 - Keep SQL and migration contracts database-first; generated language bindings are derived artifacts.
 - Keep `sql/*` helpers focused on database access only (query shape, serialization, SQL defaults).
 - Do not import `@lib/common` from this package. Runtime concerns like request IP lookup, response formatting, and SMS alerts belong in apps or `@lib/common`.
+- Fresh empty DB: run `pnpm --filter @lib/db-postgres db:migrate`, then `db:verify`.
+- Existing pre-migration DB with baseline schema already present: run `db:migrate:baseline` once, then `db:migrate`, then `db:verify`.
+- Never manually create or alter tables outside migrations.
+- Migration files are forward-only SQL; do not add `BEGIN` / `COMMIT`.
+- For populated tables, migrations must explicitly backfill data and explicitly convert types with `USING` where needed.
+- After schema changes, keep `migrations/`, `schema/current.sql`, generated artifacts, queries, and `sql/*` adapters in sync.

--- a/lib/db-postgres/README.md
+++ b/lib/db-postgres/README.md
@@ -1,0 +1,160 @@
+# @lib/db-postgres
+
+Database-first package for the `POSTGRES_URL` database.
+
+This package owns:
+
+- migration history
+- current schema snapshot
+- generated TypeScript/JSON schema artifacts
+- shared SQL query contracts
+
+If application code and database structure disagree, this package should be the
+place where the contract is fixed.
+
+## Environment
+
+Set:
+
+```bash
+export POSTGRES_URL="postgres://..."
+```
+
+## Fresh empty database
+
+Use this flow for a brand-new empty Postgres database:
+
+```bash
+pnpm --filter @lib/db-postgres db:migrate
+pnpm --filter @lib/db-postgres db:verify
+```
+
+What this does:
+
+- creates the baseline tables
+- applies all forward migrations
+- regenerates schema/type artifacts during verification
+- fails if the generated artifacts do not match the migrated DB
+
+## Existing database that already has the baseline schema
+
+Use this only if the database already contains the baseline tables from an
+older/manual setup and has not yet been put under migration tracking:
+
+```bash
+pnpm --filter @lib/db-postgres db:migrate:baseline
+pnpm --filter @lib/db-postgres db:migrate
+pnpm --filter @lib/db-postgres db:verify
+```
+
+`db:migrate:baseline` records only baseline migrations. It does **not** mark
+later migrations as applied.
+
+## Existing populated tables with schema changes
+
+The migration runner supports in-place upgrades. The migration file must define
+how existing data is handled.
+
+### Add a new column/index
+
+Recommended pattern:
+
+```sql
+ALTER TABLE public.example ADD COLUMN status text;
+
+UPDATE public.example
+SET status = 'ready'
+WHERE status IS NULL;
+
+ALTER TABLE public.example
+  ALTER COLUMN status SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS example_status_idx
+  ON public.example (status);
+```
+
+### Change a column type
+
+Write the conversion explicitly:
+
+```sql
+ALTER TABLE public.example
+  ALTER COLUMN amount TYPE numeric(18,4)
+  USING amount::numeric(18,4);
+```
+
+If the conversion is unsafe, add a new column, backfill it, update app code,
+then drop the old column in a later migration.
+
+## Commands
+
+### Apply migrations
+
+```bash
+pnpm --filter @lib/db-postgres db:migrate
+```
+
+### Verify DB contract
+
+```bash
+pnpm --filter @lib/db-postgres db:verify
+```
+
+### Create a new migration
+
+```bash
+pnpm --filter @lib/db-postgres db:migration:new -- add_order_status
+```
+
+Migration files are forward-only SQL. Do not add `BEGIN` / `COMMIT`; the runner
+wraps each file in a transaction.
+
+For operations that cannot run inside a transaction, add this marker at the top
+of the file:
+
+```sql
+-- cursor:no-transaction
+```
+
+Example use case: `CREATE INDEX CONCURRENTLY`.
+
+### Regenerate snapshot and types
+
+Use these when maintaining the package itself:
+
+```bash
+pnpm --filter @lib/db-postgres db:schema:snapshot
+pnpm --filter @lib/db-postgres db:types:generate
+```
+
+Or:
+
+```bash
+pnpm --filter @lib/db-postgres db:sync
+```
+
+For most engineering work, `db:verify` is the safer command because it checks
+reproducibility too.
+
+## CI
+
+This package is verified in GitHub Actions against a fresh Postgres container:
+
+- migrations must run on an empty DB
+- expected tables/constraints must exist
+- generated files must remain reproducible
+
+## Files to update when the schema changes
+
+- `migrations/*.sql`
+- `schema/current.sql`
+- `generated/typescript/db-types.ts`
+- `generated/contracts/db-schema.json`
+- `queries/**/*.sql` when shared SQL contracts change
+- `sql/*` adapters when application read/write code changes
+
+## Related docs
+
+- `AGENTS.md` - concise rules for engineers and AI agents
+- `migrations/README.md` - migration authoring details
+- `docs/db/management-playbook.md` - repo-wide DB workflow

--- a/lib/db-timescale/AGENTS.md
+++ b/lib/db-timescale/AGENTS.md
@@ -16,3 +16,14 @@ Database-first package for the `TIMESCALE_URL` database.
 
 Contract artifacts under this package should support future generated bindings
 for TypeScript, Python, C#, and R.
+
+## Notes
+
+- Fresh empty DB: run `pnpm --filter @lib/db-timescale db:migrate`, then `db:verify`.
+- Existing pre-migration DB with baseline schema already present: run `db:migrate:baseline` once, then `db:migrate`, then `db:verify`.
+- The migration runner creates `timescaledb` if needed; the DB role must have permission to create extensions.
+- Never manually create or alter tables outside migrations.
+- Migration files are forward-only SQL; do not add `BEGIN` / `COMMIT`.
+- For populated tables, migrations must explicitly backfill data and explicitly convert types with `USING` where needed.
+- Write Timescale operations idempotently when possible (`IF NOT EXISTS`, `if_not_exists => TRUE`).
+- After schema changes, keep `migrations/`, `schema/current.sql`, generated artifacts, queries, and app consumers in sync.

--- a/lib/db-timescale/README.md
+++ b/lib/db-timescale/README.md
@@ -1,0 +1,178 @@
+# @lib/db-timescale
+
+Database-first package for the `TIMESCALE_URL` database.
+
+This package owns:
+
+- Timescale/Postgres migration history
+- current schema snapshot
+- generated TypeScript/JSON schema artifacts
+- shared SQL query contracts for canonical candle tables
+
+If application code and the Timescale schema disagree, fix the contract here.
+
+## Environment
+
+Set:
+
+```bash
+export TIMESCALE_URL="postgres://..."
+```
+
+The target DB must support TimescaleDB. The migration runner executes:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS timescaledb
+```
+
+so the DB role must be allowed to create that extension.
+
+## Fresh empty database
+
+Use this flow for a brand-new empty Timescale/Postgres database:
+
+```bash
+pnpm --filter @lib/db-timescale db:migrate
+pnpm --filter @lib/db-timescale db:verify
+```
+
+What this does:
+
+- creates the baseline tables
+- applies forward migrations such as:
+  - `candles_1h_1m`
+  - `candles_1m_1s` contract cleanup
+  - Timescale hypertable/compression setup
+- verifies expected tables, indexes, hypertables, and generated artifacts
+
+## Existing database that already has the baseline schema
+
+Use this only if the database already contains the baseline Timescale schema
+from an older/manual setup and has not yet been put under migration tracking:
+
+```bash
+pnpm --filter @lib/db-timescale db:migrate:baseline
+pnpm --filter @lib/db-timescale db:migrate
+pnpm --filter @lib/db-timescale db:verify
+```
+
+`db:migrate:baseline` records only baseline migrations. It does **not** skip
+later forward migrations.
+
+## Existing populated tables with schema changes
+
+The migration runner supports in-place upgrades, but the migration SQL must say
+how existing data is handled.
+
+### Add a new column/index
+
+Recommended pattern:
+
+```sql
+ALTER TABLE public.example ADD COLUMN status text;
+
+UPDATE public.example
+SET status = 'ready'
+WHERE status IS NULL;
+
+ALTER TABLE public.example
+  ALTER COLUMN status SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS example_status_idx
+  ON public.example (status);
+```
+
+### Change a column type
+
+Write the conversion explicitly:
+
+```sql
+ALTER TABLE public.example
+  ALTER COLUMN amount TYPE numeric(18,4)
+  USING amount::numeric(18,4);
+```
+
+### Timescale-specific changes
+
+Write Timescale operations idempotently when possible:
+
+- `CREATE INDEX IF NOT EXISTS ...`
+- `create_hypertable(..., if_not_exists => TRUE, ...)`
+- `add_compression_policy(..., if_not_exists => TRUE)`
+
+If a future migration cannot safely transform existing data by SQL alone, the
+migration file must document the extra manual/application-side step.
+
+## Commands
+
+### Apply migrations
+
+```bash
+pnpm --filter @lib/db-timescale db:migrate
+```
+
+### Verify DB contract
+
+```bash
+pnpm --filter @lib/db-timescale db:verify
+```
+
+### Create a new migration
+
+```bash
+pnpm --filter @lib/db-timescale db:migration:new -- add_candles_4h_1m
+```
+
+Migration files are forward-only SQL. Do not add `BEGIN` / `COMMIT`; the runner
+wraps each file in a transaction.
+
+For operations that cannot run inside a transaction, add this marker at the top
+of the file:
+
+```sql
+-- cursor:no-transaction
+```
+
+Example use case: `CREATE INDEX CONCURRENTLY`.
+
+### Regenerate snapshot and types
+
+Use these when maintaining the package itself:
+
+```bash
+pnpm --filter @lib/db-timescale db:schema:snapshot
+pnpm --filter @lib/db-timescale db:types:generate
+```
+
+Or:
+
+```bash
+pnpm --filter @lib/db-timescale db:sync
+```
+
+For most engineering work, `db:verify` is the safer command because it checks
+reproducibility too.
+
+## CI
+
+This package is verified in GitHub Actions against a fresh Timescale container:
+
+- migrations must run on an empty DB
+- expected tables, indexes, and hypertables must exist
+- generated files must remain reproducible
+
+## Files to update when the schema changes
+
+- `migrations/*.sql`
+- `schema/current.sql`
+- `generated/typescript/db-types.ts`
+- `generated/contracts/db-schema.json`
+- `queries/**/*.sql` when shared SQL contracts change
+- app consumers when canonical candle contracts change
+
+## Related docs
+
+- `AGENTS.md` - concise rules for engineers and AI agents
+- `migrations/README.md` - migration authoring details
+- `docs/db/management-playbook.md` - repo-wide DB workflow
+- `apps/market-write-node/README.md` - writer app workflow using this package


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes that don’t modify runtime code or database behavior. Low risk aside from potential confusion if the new guidance is misapplied during ops.
> 
> **Overview**
> Clarifies DB *ownership and migration workflow* for `market-write-node`, explicitly directing schema changes to `@lib/db-timescale` and adding `db:verify` to the recommended deploy/bootstrap steps.
> 
> Adds new package-level READMEs for `@lib/db-timescale` and `@lib/db-postgres` and updates `AGENTS.md` guidance to standardize the “fresh DB vs baseline-existing DB” migration paths, require explicit backfill/type conversion for populated-table migrations, and note extension/transaction/idempotency expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 973c902918bc59e856dddadb3ccb55e62f525c3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->