### PR TITLE
Refactor session calendars for VWAP continuity

### DIFF
--- a/apps/market-write-node/AGENTS.md
+++ b/apps/market-write-node/AGENTS.md
@@ -22,7 +22,8 @@ second:
 - output timeframe: 1 minute
 - output write cadence: 1 second
 - short no-trade gaps are forward-filled as zero-volume seconds
-- extended inactivity resets the rolling warmup instead of stitching distant seconds together
+- extended open-market inactivity resets the rolling warmup instead of stitching distant seconds together
+- scheduled closures from the configured session calendar are treated as paused time so rolling VWAP/CVD continuity carries across closes and reopens
 
 Each `candles_1h_1m` row is the trailing 60-minute window for a ticker at that
 minute:
@@ -83,6 +84,7 @@ Key rules:
 - keep front-month stitching and rolling-window aggregation deterministic
 - prefer shared library code over duplicated live/batch logic
 - treat written tables as source-of-truth data, not disposable intermediate output
+- define market-session windows in local exchange time with an IANA time zone; do not hardcode fixed UTC close/reopen hours
 - `1h@1m` must be derived from minute-boundary `1m@1s` rows
 - do not derive `1h@1m` directly from raw trades
 - do not compute `1h` every second unless the product intentionally changes to `1h@1s`

--- a/apps/market-write-node/README.md
+++ b/apps/market-write-node/README.md
@@ -10,8 +10,10 @@ This app maintains:
 
 The shared rolling engine forward-fills short no-trade gaps as zero-volume
 seconds so minute-boundary rows stay available for the hourly layer. Extended
-gaps reset warmup instead of combining distant activity into one "continuous"
-window.
+open-market gaps reset warmup instead of combining distant activity into one
+"continuous" window. Scheduled closures from the configured session calendar are
+treated as paused time, so rolling VWAP/CVD continuity carries across closes
+and reopens without hardcoding UTC hours.
 
 ## What this app does
 
@@ -181,11 +183,22 @@ Required env vars:
 - `DATABENTO_SYMBOLS`
 - `DATABENTO_STYPE`
 
+Optional session-calendar env vars:
+
+- `MARKET_SESSION_TIME_ZONE` - IANA time zone for the trading session
+  (default: `America/Chicago`)
+- `MARKET_SESSION_OPEN_WINDOWS` - comma-separated weekly open windows in local
+  session time, for example:
+  `Sun 17:00-Mon 16:00, Mon 17:00-Tue 16:00, Tue 17:00-Wed 16:00, Wed 17:00-Thu 16:00, Thu 17:00-Fri 16:00`
+
 Live behavior:
 
 1. raw TBBO trades -> `candles_1m_1s`
 2. successful 1m writes at minute boundaries feed the hourly aggregator
 3. minute-boundary rows -> `candles_1h_1m`
+
+The live stream gates trades by the trade event timestamp in the configured
+session calendar, not by fixed UTC close/reopen assumptions.
 
 On startup, the hourly writer hydrates itself from the most recent
 minute-boundary `candles_1m_1s` rows so it does not need a fresh 60-minute

--- a/apps/market-write-node/README.md
+++ b/apps/market-write-node/README.md
@@ -185,14 +185,17 @@ Required env vars:
 
 Optional session-calendar env vars:
 
+- `MARKET_SESSION_PROFILE` - named session profile from
+  `src/lib/trade/market-session-config.ts` (default: `globex`)
 - `MARKET_SESSION_TIME_ZONE` - IANA time zone for the trading session
-  (default: `America/Chicago`)
+  (overrides the selected profile's time zone)
 - `MARKET_SESSION_OPEN_WINDOWS` - comma-separated weekly open windows in local
-  session time, for example:
+  session time (overrides the selected profile's windows), for example:
   `Sun 17:00-Mon 16:00, Mon 17:00-Tue 16:00, Tue 17:00-Wed 16:00, Wed 17:00-Thu 16:00, Thu 17:00-Fri 16:00`
 
-The default session profile is defined in
-`src/lib/trade/market-session-config.ts`.
+Session profiles live in `src/lib/trade/market-session-config.ts`. Start by
+selecting a profile, then use the time zone / open-windows env vars only when
+you need local overrides.
 
 Live behavior:
 

--- a/apps/market-write-node/README.md
+++ b/apps/market-write-node/README.md
@@ -186,7 +186,8 @@ Required env vars:
 Optional session-calendar env vars:
 
 - `MARKET_SESSION_PROFILE` - named session profile from
-  `src/lib/trade/market-session-config.ts` (default: `globex`)
+  `src/lib/trade/market-session-config.ts`; when set, it overrides per-ticker
+  profile selection for the whole process
 - `MARKET_SESSION_TIME_ZONE` - IANA time zone for the trading session
   (overrides the selected profile's time zone)
 - `MARKET_SESSION_OPEN_WINDOWS` - comma-separated weekly open windows in local
@@ -194,8 +195,10 @@ Optional session-calendar env vars:
   `Sun 17:00-Mon 16:00, Mon 17:00-Tue 16:00, Tue 17:00-Wed 16:00, Wed 17:00-Thu 16:00, Thu 17:00-Fri 16:00`
 
 Session profiles live in `src/lib/trade/market-session-config.ts`. Start by
-selecting a profile, then use the time zone / open-windows env vars only when
-you need local overrides.
+adding/adjusting entries in `SESSION_PROFILE_BY_TICKER`, then use
+`MARKET_SESSION_PROFILE` only when you intentionally want one process-wide
+override. Use the time zone / open-windows env vars only when you need local
+profile overrides.
 
 Live behavior:
 

--- a/apps/market-write-node/README.md
+++ b/apps/market-write-node/README.md
@@ -191,6 +191,9 @@ Optional session-calendar env vars:
   session time, for example:
   `Sun 17:00-Mon 16:00, Mon 17:00-Tue 16:00, Tue 17:00-Wed 16:00, Wed 17:00-Thu 16:00, Thu 17:00-Fri 16:00`
 
+The default session profile is defined in
+`src/lib/trade/market-session-config.ts`.
+
 Live behavior:
 
 1. raw TBBO trades -> `candles_1m_1s`

--- a/apps/market-write-node/docs/data-storage/candles-schema.md
+++ b/apps/market-write-node/docs/data-storage/candles-schema.md
@@ -33,8 +33,11 @@ Each row is:
 - the trailing 60-second rolling window ending at that second
 
 The shared 1m engine forward-fills short no-trade gaps as zero-volume seconds so
-minute-boundary rows remain available for the hourly layer. Extended inactivity
-resets warmup instead of stitching distant seconds into one continuous window.
+minute-boundary rows remain available for the hourly layer. Extended
+open-market inactivity resets warmup instead of stitching distant seconds into
+one continuous window, but scheduled closures from the configured session
+calendar are skipped so rolling windows remain continuous across closes and
+reopens.
 
 ### `candles_1h_1m`
 

--- a/apps/market-write-node/scripts/tbbo-1m-1s.ts
+++ b/apps/market-write-node/scripts/tbbo-1m-1s.ts
@@ -35,7 +35,15 @@ import { createReadStream } from "fs";
 import { createInterface } from "readline";
 import { pool } from "../src/lib/db.js";
 import type { NormalizedTrade, TimedTradeInput } from "../src/lib/trade/index.js";
-import { RollingWindow1m, determineTradeSide, extractTicker, toMinuteBucket, toSecondBucket, writeCandles } from "../src/lib/trade/index.js";
+import {
+  RollingWindow1m,
+  determineTradeSide,
+  extractTicker,
+  getConfiguredMarketSessionForTicker,
+  toMinuteBucket,
+  toSecondBucket,
+  writeCandles,
+} from "../src/lib/trade/index.js";
 
 interface HistoricalTbboLevel {
   bid_px?: string | number;
@@ -196,6 +204,7 @@ async function processFile(filePath: string): Promise<void> {
   });
 
   let lineCount = 0;
+  let fileTicker: string | null = null;
 
   for await (const line of rl) {
     if (!line.trim()) {
@@ -203,6 +212,10 @@ async function processFile(filePath: string): Promise<void> {
     }
 
     const parsed = parseHistoricalTbbo(line);
+    if (parsed && !fileTicker) {
+      fileTicker = parsed.trade.ticker;
+      console.log(`   🕒 Session: ${getConfiguredMarketSessionForTicker(fileTicker).describe()}`);
+    }
     if (parsed && rollingWindow.addTrade(parsed)) {
       stats.tradesProcessed++;
     }

--- a/apps/market-write-node/src/lib/trade/index.ts
+++ b/apps/market-write-node/src/lib/trade/index.ts
@@ -33,6 +33,17 @@ export {
   checkTradeAge,
 } from "./timestamp.js";
 
+// Market-session utilities
+export type { MarketSessionConfig, OpenBucketCollection, WeeklySessionWindowInput } from "./market-session.js";
+export {
+  DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
+  WeeklyMarketSession,
+  collectOpenBucketTimesBetween,
+  getConfiguredMarketSession,
+  isMarketOpenAt,
+  parseWeeklySessionWindows,
+} from "./market-session.js";
+
 // Symbol utilities
 export { extractTicker } from "./symbol.js";
 

--- a/apps/market-write-node/src/lib/trade/index.ts
+++ b/apps/market-write-node/src/lib/trade/index.ts
@@ -43,10 +43,13 @@ export {
   parseWeeklySessionWindows,
 } from "./market-session.js";
 export {
+  DEFAULT_MARKET_SESSION_PROFILE,
   DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
   DEFAULT_MARKET_SESSION_CONFIG,
+  MARKET_SESSION_PROFILE_ENV_VAR,
   MARKET_SESSION_OPEN_WINDOWS_ENV_VAR,
   MARKET_SESSION_TIME_ZONE_ENV_VAR,
+  SESSION_PROFILES,
 } from "./market-session-config.js";
 
 // Symbol utilities

--- a/apps/market-write-node/src/lib/trade/index.ts
+++ b/apps/market-write-node/src/lib/trade/index.ts
@@ -36,13 +36,18 @@ export {
 // Market-session utilities
 export type { MarketSessionConfig, OpenBucketCollection, WeeklySessionWindowInput } from "./market-session.js";
 export {
-  DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
   WeeklyMarketSession,
   collectOpenBucketTimesBetween,
   getConfiguredMarketSession,
   isMarketOpenAt,
   parseWeeklySessionWindows,
 } from "./market-session.js";
+export {
+  DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
+  DEFAULT_MARKET_SESSION_CONFIG,
+  MARKET_SESSION_OPEN_WINDOWS_ENV_VAR,
+  MARKET_SESSION_TIME_ZONE_ENV_VAR,
+} from "./market-session-config.js";
 
 // Symbol utilities
 export { extractTicker } from "./symbol.js";

--- a/apps/market-write-node/src/lib/trade/index.ts
+++ b/apps/market-write-node/src/lib/trade/index.ts
@@ -39,6 +39,8 @@ export {
   WeeklyMarketSession,
   collectOpenBucketTimesBetween,
   getConfiguredMarketSession,
+  getConfiguredMarketSessionForTicker,
+  getConfiguredMarketSessionResolver,
   isMarketOpenAt,
   parseWeeklySessionWindows,
 } from "./market-session.js";
@@ -46,9 +48,11 @@ export {
   DEFAULT_MARKET_SESSION_PROFILE,
   DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
   DEFAULT_MARKET_SESSION_CONFIG,
+  getSessionProfileForTicker,
   MARKET_SESSION_PROFILE_ENV_VAR,
   MARKET_SESSION_OPEN_WINDOWS_ENV_VAR,
   MARKET_SESSION_TIME_ZONE_ENV_VAR,
+  SESSION_PROFILE_BY_TICKER,
   SESSION_PROFILES,
 } from "./market-session-config.js";
 

--- a/apps/market-write-node/src/lib/trade/market-session-config.ts
+++ b/apps/market-write-node/src/lib/trade/market-session-config.ts
@@ -1,5 +1,6 @@
 import type { MarketSessionConfig } from "./market-session.js";
 
+export const MARKET_SESSION_PROFILE_ENV_VAR = "MARKET_SESSION_PROFILE";
 export const MARKET_SESSION_TIME_ZONE_ENV_VAR = "MARKET_SESSION_TIME_ZONE";
 export const MARKET_SESSION_OPEN_WINDOWS_ENV_VAR = "MARKET_SESSION_OPEN_WINDOWS";
 
@@ -21,4 +22,32 @@ export const DEFAULT_GLOBEX_MARKET_SESSION_CONFIG: MarketSessionConfig = {
   label: "CME Globex",
 };
 
+/**
+ * Small starter set of named session profiles.
+ *
+ * Keep this list intentionally compact for now and expand it as new markets or
+ * research workflows need distinct trading calendars.
+ */
+export const SESSION_PROFILES = {
+  globex: DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
+  tokyo_daytime: {
+    timeZone: "Asia/Tokyo",
+    weeklyLocalWindows: [
+      { startDay: "Mon", startTime: "09:00", endDay: "Mon", endTime: "11:30" },
+      { startDay: "Mon", startTime: "12:30", endDay: "Mon", endTime: "15:00" },
+      { startDay: "Tue", startTime: "09:00", endDay: "Tue", endTime: "11:30" },
+      { startDay: "Tue", startTime: "12:30", endDay: "Tue", endTime: "15:00" },
+      { startDay: "Wed", startTime: "09:00", endDay: "Wed", endTime: "11:30" },
+      { startDay: "Wed", startTime: "12:30", endDay: "Wed", endTime: "15:00" },
+      { startDay: "Thu", startTime: "09:00", endDay: "Thu", endTime: "11:30" },
+      { startDay: "Thu", startTime: "12:30", endDay: "Thu", endTime: "15:00" },
+      { startDay: "Fri", startTime: "09:00", endDay: "Fri", endTime: "11:30" },
+      { startDay: "Fri", startTime: "12:30", endDay: "Fri", endTime: "15:00" },
+    ],
+    label: "Tokyo daytime",
+  },
+} as const satisfies Record<string, MarketSessionConfig>;
+
+export type MarketSessionProfileName = keyof typeof SESSION_PROFILES;
+export const DEFAULT_MARKET_SESSION_PROFILE: MarketSessionProfileName = "globex";
 export const DEFAULT_MARKET_SESSION_CONFIG = DEFAULT_GLOBEX_MARKET_SESSION_CONFIG;

--- a/apps/market-write-node/src/lib/trade/market-session-config.ts
+++ b/apps/market-write-node/src/lib/trade/market-session-config.ts
@@ -51,3 +51,31 @@ export const SESSION_PROFILES = {
 export type MarketSessionProfileName = keyof typeof SESSION_PROFILES;
 export const DEFAULT_MARKET_SESSION_PROFILE: MarketSessionProfileName = "globex";
 export const DEFAULT_MARKET_SESSION_CONFIG = DEFAULT_GLOBEX_MARKET_SESSION_CONFIG;
+
+/**
+ * Per-ticker profile assignments for the canonical writer.
+ *
+ * Unlisted tickers fall back to the process-level default profile (or env
+ * override). Keep this map small and explicit; extend it only as new markets
+ * are added to the write pipeline.
+ */
+export const SESSION_PROFILE_BY_TICKER: Partial<Record<string, MarketSessionProfileName>> = {
+  ES: "globex",
+  NQ: "globex",
+  RTY: "globex",
+  YM: "globex",
+  CL: "globex",
+  GC: "globex",
+  SI: "globex",
+  HG: "globex",
+  NK: "tokyo_daytime",
+};
+
+export function getSessionProfileForTicker(ticker: string): MarketSessionProfileName | null {
+  const normalizedTicker = ticker.trim().toUpperCase();
+  if (!normalizedTicker) {
+    return null;
+  }
+
+  return SESSION_PROFILE_BY_TICKER[normalizedTicker] ?? null;
+}

--- a/apps/market-write-node/src/lib/trade/market-session-config.ts
+++ b/apps/market-write-node/src/lib/trade/market-session-config.ts
@@ -1,0 +1,24 @@
+import type { MarketSessionConfig } from "./market-session.js";
+
+export const MARKET_SESSION_TIME_ZONE_ENV_VAR = "MARKET_SESSION_TIME_ZONE";
+export const MARKET_SESSION_OPEN_WINDOWS_ENV_VAR = "MARKET_SESSION_OPEN_WINDOWS";
+
+/**
+ * Default session profile for CME Globex-style futures traded in Chicago time.
+ *
+ * This remains intentionally simple for now: recurring weekly open windows
+ * without holiday overrides. Future profiles can be added here incrementally.
+ */
+export const DEFAULT_GLOBEX_MARKET_SESSION_CONFIG: MarketSessionConfig = {
+  timeZone: "America/Chicago",
+  weeklyLocalWindows: [
+    { startDay: "Sun", startTime: "17:00", endDay: "Mon", endTime: "16:00" },
+    { startDay: "Mon", startTime: "17:00", endDay: "Tue", endTime: "16:00" },
+    { startDay: "Tue", startTime: "17:00", endDay: "Wed", endTime: "16:00" },
+    { startDay: "Wed", startTime: "17:00", endDay: "Thu", endTime: "16:00" },
+    { startDay: "Thu", startTime: "17:00", endDay: "Fri", endTime: "16:00" },
+  ],
+  label: "CME Globex",
+};
+
+export const DEFAULT_MARKET_SESSION_CONFIG = DEFAULT_GLOBEX_MARKET_SESSION_CONFIG;

--- a/apps/market-write-node/src/lib/trade/market-session.test.ts
+++ b/apps/market-write-node/src/lib/trade/market-session.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
+  WeeklyMarketSession,
+  collectOpenBucketTimesBetween,
+} from "./market-session.js";
+
+test("Globex session follows winter and summer DST boundaries in the configured time zone", () => {
+  const session = new WeeklyMarketSession(DEFAULT_GLOBEX_MARKET_SESSION_CONFIG);
+
+  assert.equal(session.isOpenAt(new Date("2026-01-05T21:59:59.000Z")), true);
+  assert.equal(session.isOpenAt(new Date("2026-01-05T22:00:00.000Z")), false);
+  assert.equal(session.isOpenAt(new Date("2026-01-05T22:59:59.000Z")), false);
+  assert.equal(session.isOpenAt(new Date("2026-01-05T23:00:00.000Z")), true);
+
+  assert.equal(session.isOpenAt(new Date("2026-03-09T20:59:59.000Z")), true);
+  assert.equal(session.isOpenAt(new Date("2026-03-09T21:00:00.000Z")), false);
+  assert.equal(session.isOpenAt(new Date("2026-03-09T21:59:59.000Z")), false);
+  assert.equal(session.isOpenAt(new Date("2026-03-09T22:00:00.000Z")), true);
+});
+
+test("next open calculation skips closed periods using local session time", () => {
+  const session = new WeeklyMarketSession(DEFAULT_GLOBEX_MARKET_SESSION_CONFIG);
+
+  const nextWinterOpenMs = session.getNextOpenMs(new Date("2026-01-05T22:15:00.000Z").getTime());
+  assert.equal(new Date(nextWinterOpenMs).toISOString(), "2026-01-05T23:00:00.000Z");
+
+  const nextSummerOpenMs = session.getNextOpenMs(new Date("2026-03-09T21:15:00.000Z").getTime());
+  assert.equal(new Date(nextSummerOpenMs).toISOString(), "2026-03-09T22:00:00.000Z");
+});
+
+test("session helpers support non-US time zones and multiple daily windows", () => {
+  const session = new WeeklyMarketSession({
+    timeZone: "Asia/Tokyo",
+    weeklyLocalWindows: [
+      { startDay: "Mon", startTime: "09:00", endDay: "Mon", endTime: "11:30" },
+      { startDay: "Mon", startTime: "12:30", endDay: "Mon", endTime: "15:00" },
+    ],
+    label: "Tokyo daytime",
+  });
+
+  assert.equal(session.isOpenAt(new Date("2026-01-05T00:30:00.000Z")), true);
+  assert.equal(session.isOpenAt(new Date("2026-01-05T03:00:00.000Z")), false);
+  assert.equal(session.isOpenAt(new Date("2026-01-05T04:30:00.000Z")), true);
+
+  const nextOpenMs = session.getNextOpenMs(new Date("2026-01-05T03:00:00.000Z").getTime());
+  assert.equal(new Date(nextOpenMs).toISOString(), "2026-01-05T03:30:00.000Z");
+
+  const openBuckets = collectOpenBucketTimesBetween(
+    new Date("2026-01-05T03:00:00.000Z").getTime(),
+    new Date("2026-01-05T04:30:00.000Z").getTime(),
+    30 * 60 * 1000,
+    10,
+    session,
+  );
+  assert.deepEqual(
+    openBuckets.bucketTimes.map((timeMs) => new Date(timeMs).toISOString()),
+    ["2026-01-05T03:30:00.000Z", "2026-01-05T04:00:00.000Z"],
+  );
+});

--- a/apps/market-write-node/src/lib/trade/market-session.test.ts
+++ b/apps/market-write-node/src/lib/trade/market-session.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { DEFAULT_GLOBEX_MARKET_SESSION_CONFIG } from "./market-session-config.js";
 import {
-  DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
   WeeklyMarketSession,
   collectOpenBucketTimesBetween,
 } from "./market-session.js";

--- a/apps/market-write-node/src/lib/trade/market-session.test.ts
+++ b/apps/market-write-node/src/lib/trade/market-session.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
+  getSessionProfileForTicker,
   MARKET_SESSION_OPEN_WINDOWS_ENV_VAR,
   MARKET_SESSION_PROFILE_ENV_VAR,
   MARKET_SESSION_TIME_ZONE_ENV_VAR,
@@ -10,6 +11,7 @@ import {
 } from "./market-session-config.js";
 import {
   getConfiguredMarketSession,
+  getConfiguredMarketSessionForTicker,
   WeeklyMarketSession,
   collectOpenBucketTimesBetween,
 } from "./market-session.js";
@@ -74,6 +76,17 @@ test("configured session can select a named profile and still allow env override
   });
   assert.equal(overriddenSession.isOpenAt(new Date("2026-01-05T00:30:00.000Z")), true);
   assert.equal(overriddenSession.isOpenAt(new Date("2026-01-05T02:00:00.000Z")), false);
+});
+
+test("configured session resolves named profiles from ticker mappings", () => {
+  assert.equal(getSessionProfileForTicker("ES"), "globex");
+  assert.equal(getSessionProfileForTicker("NK"), "tokyo_daytime");
+  assert.equal(getSessionProfileForTicker("UNKNOWN"), null);
+
+  const esSession = getConfiguredMarketSessionForTicker("ES");
+  const nkSession = getConfiguredMarketSessionForTicker("NK");
+  assert.equal(esSession.describe(), new WeeklyMarketSession(SESSION_PROFILES.globex).describe());
+  assert.equal(nkSession.describe(), new WeeklyMarketSession(SESSION_PROFILES.tokyo_daytime).describe());
 });
 
 test("configured session still honors an explicit fallback when no profile env var is set", () => {

--- a/apps/market-write-node/src/lib/trade/market-session.test.ts
+++ b/apps/market-write-node/src/lib/trade/market-session.test.ts
@@ -1,8 +1,15 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { DEFAULT_GLOBEX_MARKET_SESSION_CONFIG } from "./market-session-config.js";
 import {
+  DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
+  MARKET_SESSION_OPEN_WINDOWS_ENV_VAR,
+  MARKET_SESSION_PROFILE_ENV_VAR,
+  MARKET_SESSION_TIME_ZONE_ENV_VAR,
+  SESSION_PROFILES,
+} from "./market-session-config.js";
+import {
+  getConfiguredMarketSession,
   WeeklyMarketSession,
   collectOpenBucketTimesBetween,
 } from "./market-session.js";
@@ -32,14 +39,7 @@ test("next open calculation skips closed periods using local session time", () =
 });
 
 test("session helpers support non-US time zones and multiple daily windows", () => {
-  const session = new WeeklyMarketSession({
-    timeZone: "Asia/Tokyo",
-    weeklyLocalWindows: [
-      { startDay: "Mon", startTime: "09:00", endDay: "Mon", endTime: "11:30" },
-      { startDay: "Mon", startTime: "12:30", endDay: "Mon", endTime: "15:00" },
-    ],
-    label: "Tokyo daytime",
-  });
+  const session = new WeeklyMarketSession(SESSION_PROFILES.tokyo_daytime);
 
   assert.equal(session.isOpenAt(new Date("2026-01-05T00:30:00.000Z")), true);
   assert.equal(session.isOpenAt(new Date("2026-01-05T03:00:00.000Z")), false);
@@ -58,5 +58,44 @@ test("session helpers support non-US time zones and multiple daily windows", () 
   assert.deepEqual(
     openBuckets.bucketTimes.map((timeMs) => new Date(timeMs).toISOString()),
     ["2026-01-05T03:30:00.000Z", "2026-01-05T04:00:00.000Z"],
+  );
+});
+
+test("configured session can select a named profile and still allow env overrides", () => {
+  const tokyoSession = getConfiguredMarketSession({
+    [MARKET_SESSION_PROFILE_ENV_VAR]: "tokyo_daytime",
+  });
+  assert.equal(tokyoSession.describe(), new WeeklyMarketSession(SESSION_PROFILES.tokyo_daytime).describe());
+
+  const overriddenSession = getConfiguredMarketSession({
+    [MARKET_SESSION_PROFILE_ENV_VAR]: "tokyo_daytime",
+    [MARKET_SESSION_TIME_ZONE_ENV_VAR]: "UTC",
+    [MARKET_SESSION_OPEN_WINDOWS_ENV_VAR]: "Mon 00:00-Mon 01:00",
+  });
+  assert.equal(overriddenSession.isOpenAt(new Date("2026-01-05T00:30:00.000Z")), true);
+  assert.equal(overriddenSession.isOpenAt(new Date("2026-01-05T02:00:00.000Z")), false);
+});
+
+test("configured session still honors an explicit fallback when no profile env var is set", () => {
+  const fallbackSession = getConfiguredMarketSession(
+    {},
+    {
+      timeZone: "UTC",
+      weeklyLocalWindows: [{ startDay: "Mon", startTime: "00:00", endDay: "Mon", endTime: "01:00" }],
+      label: "Fallback only",
+    },
+  );
+
+  assert.equal(fallbackSession.isOpenAt(new Date("2026-01-05T00:30:00.000Z")), true);
+  assert.equal(fallbackSession.isOpenAt(new Date("2026-01-05T02:00:00.000Z")), false);
+});
+
+test("configured session rejects unknown named profiles", () => {
+  assert.throws(
+    () =>
+      getConfiguredMarketSession({
+        [MARKET_SESSION_PROFILE_ENV_VAR]: "does_not_exist",
+      }),
+    /Unknown MARKET_SESSION_PROFILE/,
   );
 });

--- a/apps/market-write-node/src/lib/trade/market-session.ts
+++ b/apps/market-write-node/src/lib/trade/market-session.ts
@@ -1,0 +1,491 @@
+/**
+ * Time-zone aware recurring market-session helpers.
+ *
+ * Sessions are defined as weekly open windows in the market's local time zone.
+ * This keeps gap handling aligned with the exchange session calendar instead of
+ * hardcoding UTC close/reopen hours that break during daylight saving changes.
+ */
+
+const MINUTES_PER_DAY = 24 * 60;
+const MINUTES_PER_WEEK = 7 * MINUTES_PER_DAY;
+const SEARCH_WINDOW_MS = 36 * 60 * 60 * 1000;
+const SEARCH_STEP_MS = 60 * 1000;
+
+const DAY_NAME_TO_INDEX = {
+  sun: 0,
+  mon: 1,
+  tue: 2,
+  wed: 3,
+  thu: 4,
+  fri: 5,
+  sat: 6,
+} as const;
+
+const INDEX_TO_DAY_NAME = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+type SessionDayName = keyof typeof DAY_NAME_TO_INDEX;
+
+interface LocalDateParts {
+  year: number;
+  month: number;
+  day: number;
+}
+
+interface LocalDateTimeParts extends LocalDateParts {
+  hour: number;
+  minute: number;
+  second: number;
+  millisecond: number;
+}
+
+interface ZonedDateTimeParts extends LocalDateTimeParts {
+  weekday: number;
+}
+
+interface NormalizedWeeklySessionWindow {
+  startDay: number;
+  startMinute: number;
+  endDay: number;
+  endMinute: number;
+  startMinuteOfWeek: number;
+  endMinuteOfWeek: number;
+}
+
+export interface OpenBucketCollection {
+  bucketTimes: number[];
+  openBucketCount: number;
+  exceeded: boolean;
+}
+
+export interface WeeklySessionWindowInput {
+  startDay: number | SessionDayName | Uppercase<SessionDayName> | Capitalize<SessionDayName>;
+  startTime: string;
+  endDay: number | SessionDayName | Uppercase<SessionDayName> | Capitalize<SessionDayName>;
+  endTime: string;
+}
+
+export interface MarketSessionConfig {
+  timeZone: string;
+  weeklyLocalWindows: WeeklySessionWindowInput[];
+  label?: string;
+}
+
+export const DEFAULT_GLOBEX_MARKET_SESSION_CONFIG: MarketSessionConfig = {
+  timeZone: "America/Chicago",
+  weeklyLocalWindows: [
+    { startDay: "Sun", startTime: "17:00", endDay: "Mon", endTime: "16:00" },
+    { startDay: "Mon", startTime: "17:00", endDay: "Tue", endTime: "16:00" },
+    { startDay: "Tue", startTime: "17:00", endDay: "Wed", endTime: "16:00" },
+    { startDay: "Wed", startTime: "17:00", endDay: "Thu", endTime: "16:00" },
+    { startDay: "Thu", startTime: "17:00", endDay: "Fri", endTime: "16:00" },
+  ],
+  label: "CME Globex",
+};
+
+const zonedDateTimeFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getZonedDateTimeFormatter(timeZone: string): Intl.DateTimeFormat {
+  const cached = zonedDateTimeFormatterCache.get(timeZone);
+  if (cached) {
+    return cached;
+  }
+
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    weekday: "short",
+    hourCycle: "h23",
+  });
+  zonedDateTimeFormatterCache.set(timeZone, formatter);
+  return formatter;
+}
+
+function normalizeDay(day: WeeklySessionWindowInput["startDay"]): number {
+  if (typeof day === "number") {
+    if (day < 0 || day > 6 || !Number.isInteger(day)) {
+      throw new Error(`Invalid session weekday index "${day}". Expected integer 0-6.`);
+    }
+    return day;
+  }
+
+  const normalized = day.toLowerCase().slice(0, 3) as SessionDayName;
+  const value = DAY_NAME_TO_INDEX[normalized];
+  if (value === undefined) {
+    throw new Error(`Invalid session weekday "${day}". Expected Sun/Mon/Tue/Wed/Thu/Fri/Sat.`);
+  }
+  return value;
+}
+
+function parseTimeOfDay(time: string): number {
+  const match = /^(\d{2}):(\d{2})$/.exec(time.trim());
+  if (!match) {
+    throw new Error(`Invalid session time "${time}". Expected HH:MM in 24-hour format.`);
+  }
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (hours > 23 || minutes > 59) {
+    throw new Error(`Invalid session time "${time}". Expected HH:MM in 24-hour format.`);
+  }
+
+  return hours * 60 + minutes;
+}
+
+function formatTimeOfDay(totalMinutes: number): string {
+  const hours = Math.floor(totalMinutes / 60)
+    .toString()
+    .padStart(2, "0");
+  const minutes = (totalMinutes % 60).toString().padStart(2, "0");
+  return `${hours}:${minutes}`;
+}
+
+function normalizeWeeklySessionWindow(window: WeeklySessionWindowInput): NormalizedWeeklySessionWindow {
+  const startDay = normalizeDay(window.startDay);
+  const endDay = normalizeDay(window.endDay);
+  const startMinute = parseTimeOfDay(window.startTime);
+  const endMinute = parseTimeOfDay(window.endTime);
+
+  const startMinuteOfWeek = startDay * MINUTES_PER_DAY + startMinute;
+  let endMinuteOfWeek = endDay * MINUTES_PER_DAY + endMinute;
+  if (endMinuteOfWeek <= startMinuteOfWeek) {
+    endMinuteOfWeek += MINUTES_PER_WEEK;
+  }
+
+  return {
+    startDay,
+    startMinute,
+    endDay,
+    endMinute,
+    startMinuteOfWeek,
+    endMinuteOfWeek,
+  };
+}
+
+function getZonedDateTimeParts(date: Date, timeZone: string): ZonedDateTimeParts {
+  const parts = getZonedDateTimeFormatter(timeZone).formatToParts(date);
+
+  let year = 0;
+  let month = 0;
+  let day = 0;
+  let hour = 0;
+  let minute = 0;
+  let second = 0;
+  let weekday = 0;
+
+  for (const part of parts) {
+    switch (part.type) {
+      case "year":
+        year = Number(part.value);
+        break;
+      case "month":
+        month = Number(part.value);
+        break;
+      case "day":
+        day = Number(part.value);
+        break;
+      case "hour":
+        hour = Number(part.value);
+        break;
+      case "minute":
+        minute = Number(part.value);
+        break;
+      case "second":
+        second = Number(part.value);
+        break;
+      case "weekday":
+        weekday = normalizeDay(part.value as WeeklySessionWindowInput["startDay"]);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return {
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
+    millisecond: date.getUTCMilliseconds(),
+    weekday,
+  };
+}
+
+function getWeekMinute(parts: ZonedDateTimeParts): number {
+  return (
+    parts.weekday * MINUTES_PER_DAY +
+    parts.hour * 60 +
+    parts.minute +
+    parts.second / 60 +
+    parts.millisecond / 60000
+  );
+}
+
+function addDays(localDate: LocalDateParts, dayOffset: number): LocalDateParts {
+  const date = new Date(Date.UTC(localDate.year, localDate.month - 1, localDate.day));
+  date.setUTCDate(date.getUTCDate() + dayOffset);
+  return {
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth() + 1,
+    day: date.getUTCDate(),
+  };
+}
+
+function getTimeZoneOffsetMs(utcMs: number, timeZone: string): number {
+  const utcDate = new Date(utcMs);
+  const zoned = getZonedDateTimeParts(utcDate, timeZone);
+  const interpretedAsUtc = Date.UTC(
+    zoned.year,
+    zoned.month - 1,
+    zoned.day,
+    zoned.hour,
+    zoned.minute,
+    zoned.second,
+    utcDate.getUTCMilliseconds(),
+  );
+
+  return interpretedAsUtc - utcMs;
+}
+
+function localPartsMatch(utcMs: number, localDateTime: LocalDateTimeParts, timeZone: string): boolean {
+  const zoned = getZonedDateTimeParts(new Date(utcMs), timeZone);
+  return (
+    zoned.year === localDateTime.year &&
+    zoned.month === localDateTime.month &&
+    zoned.day === localDateTime.day &&
+    zoned.hour === localDateTime.hour &&
+    zoned.minute === localDateTime.minute &&
+    zoned.second === localDateTime.second
+  );
+}
+
+function resolveLocalDateTimeToUtcMs(localDateTime: LocalDateTimeParts, timeZone: string): number {
+  const interpretedAsUtc = Date.UTC(
+    localDateTime.year,
+    localDateTime.month - 1,
+    localDateTime.day,
+    localDateTime.hour,
+    localDateTime.minute,
+    localDateTime.second,
+    localDateTime.millisecond,
+  );
+
+  let candidateMs = interpretedAsUtc;
+  for (let i = 0; i < 4; i++) {
+    const offsetMs = getTimeZoneOffsetMs(candidateMs, timeZone);
+    const adjustedMs = interpretedAsUtc - offsetMs;
+    if (adjustedMs === candidateMs) {
+      break;
+    }
+    candidateMs = adjustedMs;
+  }
+
+  if (localPartsMatch(candidateMs, localDateTime, timeZone)) {
+    return candidateMs;
+  }
+
+  for (let probeMs = interpretedAsUtc - SEARCH_WINDOW_MS; probeMs <= interpretedAsUtc + SEARCH_WINDOW_MS; probeMs += SEARCH_STEP_MS) {
+    if (localPartsMatch(probeMs, localDateTime, timeZone)) {
+      return probeMs;
+    }
+  }
+
+  throw new Error(
+    `Could not resolve local session time ` +
+      `${localDateTime.year}-${String(localDateTime.month).padStart(2, "0")}-${String(localDateTime.day).padStart(2, "0")} ` +
+      `${String(localDateTime.hour).padStart(2, "0")}:${String(localDateTime.minute).padStart(2, "0")}` +
+      ` in time zone ${timeZone}.`,
+  );
+}
+
+export class WeeklyMarketSession {
+  readonly timeZone: string;
+  readonly label?: string;
+  readonly weeklyLocalWindows: ReadonlyArray<NormalizedWeeklySessionWindow>;
+
+  constructor(config: MarketSessionConfig) {
+    if (config.weeklyLocalWindows.length === 0) {
+      throw new Error("Market session requires at least one weekly local window.");
+    }
+
+    // Validate the time zone eagerly so bad config fails fast.
+    getZonedDateTimeFormatter(config.timeZone);
+
+    this.timeZone = config.timeZone;
+    this.label = config.label;
+    this.weeklyLocalWindows = config.weeklyLocalWindows.map(normalizeWeeklySessionWindow);
+  }
+
+  isOpenAt(input: Date | number): boolean {
+    const date = typeof input === "number" ? new Date(input) : input;
+    const minuteOfWeek = getWeekMinute(getZonedDateTimeParts(date, this.timeZone));
+    const minuteOfWeekNextCycle = minuteOfWeek + MINUTES_PER_WEEK;
+
+    return this.weeklyLocalWindows.some(
+      (window) =>
+        (minuteOfWeek >= window.startMinuteOfWeek && minuteOfWeek < window.endMinuteOfWeek) ||
+        (minuteOfWeekNextCycle >= window.startMinuteOfWeek && minuteOfWeekNextCycle < window.endMinuteOfWeek),
+    );
+  }
+
+  getNextOpenMs(currentMs: number): number {
+    if (this.isOpenAt(currentMs)) {
+      return currentMs;
+    }
+
+    const currentParts = getZonedDateTimeParts(new Date(currentMs), this.timeZone);
+    const currentLocalDate: LocalDateParts = {
+      year: currentParts.year,
+      month: currentParts.month,
+      day: currentParts.day,
+    };
+
+    let nextOpenMs = Number.POSITIVE_INFINITY;
+
+    for (let dayOffset = 0; dayOffset <= 7; dayOffset++) {
+      const localDate = addDays(currentLocalDate, dayOffset);
+      const weekday = new Date(Date.UTC(localDate.year, localDate.month - 1, localDate.day)).getUTCDay();
+
+      for (const window of this.weeklyLocalWindows) {
+        if (window.startDay !== weekday) {
+          continue;
+        }
+
+        const candidateMs = resolveLocalDateTimeToUtcMs(
+          {
+            ...localDate,
+            hour: Math.floor(window.startMinute / 60),
+            minute: window.startMinute % 60,
+            second: 0,
+            millisecond: 0,
+          },
+          this.timeZone,
+        );
+
+        if (candidateMs > currentMs && candidateMs < nextOpenMs) {
+          nextOpenMs = candidateMs;
+        }
+      }
+    }
+
+    return Number.isFinite(nextOpenMs) ? nextOpenMs : currentMs;
+  }
+
+  collectOpenBucketTimesBetween(
+    startMsInclusive: number,
+    endMsExclusive: number,
+    stepMs: number,
+    maxOpenBuckets: number,
+  ): OpenBucketCollection {
+    const bucketTimes: number[] = [];
+    let openBucketCount = 0;
+    let currentMs = startMsInclusive;
+
+    while (currentMs < endMsExclusive) {
+      if (!this.isOpenAt(currentMs)) {
+        const nextOpenMs = this.getNextOpenMs(currentMs);
+        currentMs = nextOpenMs > currentMs ? nextOpenMs : currentMs + stepMs;
+        continue;
+      }
+
+      openBucketCount++;
+      if (openBucketCount > maxOpenBuckets) {
+        return {
+          bucketTimes,
+          openBucketCount,
+          exceeded: true,
+        };
+      }
+
+      bucketTimes.push(currentMs);
+      currentMs += stepMs;
+    }
+
+    return {
+      bucketTimes,
+      openBucketCount,
+      exceeded: false,
+    };
+  }
+
+  describe(): string {
+    const windowText = this.weeklyLocalWindows
+      .map(
+        (window) =>
+          `${INDEX_TO_DAY_NAME[window.startDay]} ${formatTimeOfDay(window.startMinute)}-` +
+          `${INDEX_TO_DAY_NAME[window.endDay]} ${formatTimeOfDay(window.endMinute)}`,
+      )
+      .join(", ");
+
+    return `${this.label ? `${this.label} ` : ""}${this.timeZone} [${windowText}]`;
+  }
+}
+
+export function parseWeeklySessionWindows(value: string): WeeklySessionWindowInput[] {
+  return value
+    .split(",")
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .map((segment) => {
+      const match = /^([A-Za-z]{3})\s+(\d{2}:\d{2})\s*-\s*([A-Za-z]{3})\s+(\d{2}:\d{2})$/.exec(segment);
+      if (!match) {
+        throw new Error(
+          `Invalid MARKET_SESSION_OPEN_WINDOWS segment "${segment}". ` +
+            `Expected format like "Sun 17:00-Mon 16:00".`,
+        );
+      }
+
+      return {
+        startDay: match[1] as WeeklySessionWindowInput["startDay"],
+        startTime: match[2],
+        endDay: match[3] as WeeklySessionWindowInput["endDay"],
+        endTime: match[4],
+      };
+    });
+}
+
+let cachedConfiguredSession: WeeklyMarketSession | null = null;
+let cachedConfiguredSessionKey: string | null = null;
+
+export function getConfiguredMarketSession(
+  env: NodeJS.ProcessEnv = process.env,
+  fallback: MarketSessionConfig = DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
+): WeeklyMarketSession {
+  const timeZone = env.MARKET_SESSION_TIME_ZONE?.trim() || fallback.timeZone;
+  const openWindows = env.MARKET_SESSION_OPEN_WINDOWS?.trim();
+  const cacheKey = `${timeZone}||${openWindows ?? ""}`;
+
+  if (cachedConfiguredSession && cachedConfiguredSessionKey === cacheKey) {
+    return cachedConfiguredSession;
+  }
+
+  const weeklyLocalWindows = openWindows ? parseWeeklySessionWindows(openWindows) : fallback.weeklyLocalWindows;
+
+  cachedConfiguredSession = new WeeklyMarketSession({
+    timeZone,
+    weeklyLocalWindows,
+    label: fallback.label,
+  });
+  cachedConfiguredSessionKey = cacheKey;
+  return cachedConfiguredSession;
+}
+
+export function isMarketOpenAt(date: Date, session: WeeklyMarketSession = getConfiguredMarketSession()): boolean {
+  return session.isOpenAt(date);
+}
+
+export function collectOpenBucketTimesBetween(
+  startMsInclusive: number,
+  endMsExclusive: number,
+  stepMs: number,
+  maxOpenBuckets: number,
+  session: WeeklyMarketSession = getConfiguredMarketSession(),
+): OpenBucketCollection {
+  return session.collectOpenBucketTimesBetween(startMsInclusive, endMsExclusive, stepMs, maxOpenBuckets);
+}

--- a/apps/market-write-node/src/lib/trade/market-session.ts
+++ b/apps/market-write-node/src/lib/trade/market-session.ts
@@ -7,9 +7,12 @@
  */
 
 import {
+  DEFAULT_MARKET_SESSION_PROFILE,
   DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
+  MARKET_SESSION_PROFILE_ENV_VAR,
   MARKET_SESSION_OPEN_WINDOWS_ENV_VAR,
   MARKET_SESSION_TIME_ZONE_ENV_VAR,
+  SESSION_PROFILES,
 } from "./market-session-config.js";
 
 const MINUTES_PER_DAY = 24 * 60;
@@ -453,20 +456,30 @@ export function getConfiguredMarketSession(
   env: NodeJS.ProcessEnv = process.env,
   fallback: MarketSessionConfig = DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
 ): WeeklyMarketSession {
-  const timeZone = env[MARKET_SESSION_TIME_ZONE_ENV_VAR]?.trim() || fallback.timeZone;
+  const profileName = env[MARKET_SESSION_PROFILE_ENV_VAR]?.trim() || null;
+  const profileConfig = profileName ? SESSION_PROFILES[profileName as keyof typeof SESSION_PROFILES] : null;
+  if (profileName && !profileConfig) {
+    throw new Error(
+      `Unknown ${MARKET_SESSION_PROFILE_ENV_VAR} "${profileName}". ` +
+        `Expected one of: ${Object.keys(SESSION_PROFILES).join(", ")}.`,
+    );
+  }
+
+  const baseConfig = profileConfig ?? fallback;
+  const timeZone = env[MARKET_SESSION_TIME_ZONE_ENV_VAR]?.trim() || baseConfig.timeZone;
   const openWindows = env[MARKET_SESSION_OPEN_WINDOWS_ENV_VAR]?.trim();
-  const cacheKey = `${timeZone}||${openWindows ?? ""}`;
+  const cacheKey = `${profileName ?? DEFAULT_MARKET_SESSION_PROFILE}||${timeZone}||${openWindows ?? ""}`;
 
   if (cachedConfiguredSession && cachedConfiguredSessionKey === cacheKey) {
     return cachedConfiguredSession;
   }
 
-  const weeklyLocalWindows = openWindows ? parseWeeklySessionWindows(openWindows) : fallback.weeklyLocalWindows;
+  const weeklyLocalWindows = openWindows ? parseWeeklySessionWindows(openWindows) : baseConfig.weeklyLocalWindows;
 
   cachedConfiguredSession = new WeeklyMarketSession({
     timeZone,
     weeklyLocalWindows,
-    label: fallback.label,
+    label: baseConfig.label,
   });
   cachedConfiguredSessionKey = cacheKey;
   return cachedConfiguredSession;

--- a/apps/market-write-node/src/lib/trade/market-session.ts
+++ b/apps/market-write-node/src/lib/trade/market-session.ts
@@ -9,6 +9,7 @@
 import {
   DEFAULT_MARKET_SESSION_PROFILE,
   DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
+  getSessionProfileForTicker,
   MARKET_SESSION_PROFILE_ENV_VAR,
   MARKET_SESSION_OPEN_WINDOWS_ENV_VAR,
   MARKET_SESSION_TIME_ZONE_ENV_VAR,
@@ -80,6 +81,7 @@ export interface MarketSessionConfig {
 }
 
 export { DEFAULT_GLOBEX_MARKET_SESSION_CONFIG } from "./market-session-config.js";
+export type MarketSessionResolver = (ticker: string) => WeeklyMarketSession;
 
 const zonedDateTimeFormatterCache = new Map<string, Intl.DateTimeFormat>();
 
@@ -449,40 +451,94 @@ export function parseWeeklySessionWindows(value: string): WeeklySessionWindowInp
     });
 }
 
-let cachedConfiguredSession: WeeklyMarketSession | null = null;
-let cachedConfiguredSessionKey: string | null = null;
+const configuredSessionCache = new Map<string, WeeklyMarketSession>();
+
+function serializeSessionConfig(config: MarketSessionConfig): string {
+  return JSON.stringify({
+    label: config.label ?? "",
+    timeZone: config.timeZone,
+    weeklyLocalWindows: config.weeklyLocalWindows,
+  });
+}
+
+function getConfiguredSessionSelection(
+  ticker: string | null,
+  env: NodeJS.ProcessEnv,
+  fallback: MarketSessionConfig,
+): {
+  profileName: string | null;
+  baseConfig: MarketSessionConfig;
+} {
+  const explicitProfileName = env[MARKET_SESSION_PROFILE_ENV_VAR]?.trim() || null;
+  if (explicitProfileName) {
+    const explicitProfile = SESSION_PROFILES[explicitProfileName as keyof typeof SESSION_PROFILES];
+    if (!explicitProfile) {
+      throw new Error(
+        `Unknown ${MARKET_SESSION_PROFILE_ENV_VAR} "${explicitProfileName}". ` +
+          `Expected one of: ${Object.keys(SESSION_PROFILES).join(", ")}.`,
+      );
+    }
+
+    return {
+      profileName: explicitProfileName,
+      baseConfig: explicitProfile,
+    };
+  }
+
+  const tickerProfileName = ticker ? getSessionProfileForTicker(ticker) : null;
+  if (tickerProfileName) {
+    return {
+      profileName: tickerProfileName,
+      baseConfig: SESSION_PROFILES[tickerProfileName],
+    };
+  }
+
+  return {
+    profileName: null,
+    baseConfig: fallback,
+  };
+}
+
+export function getConfiguredMarketSessionForTicker(
+  ticker: string,
+  env: NodeJS.ProcessEnv = process.env,
+  fallback: MarketSessionConfig = DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
+): WeeklyMarketSession {
+  const normalizedTicker = ticker.trim().toUpperCase();
+  const { profileName, baseConfig } = getConfiguredSessionSelection(normalizedTicker, env, fallback);
+  const timeZone = env[MARKET_SESSION_TIME_ZONE_ENV_VAR]?.trim() || baseConfig.timeZone;
+  const openWindows = env[MARKET_SESSION_OPEN_WINDOWS_ENV_VAR]?.trim();
+  const cacheKey =
+    `${profileName ?? DEFAULT_MARKET_SESSION_PROFILE}||${normalizedTicker}||${timeZone}||${openWindows ?? ""}||` +
+    `${serializeSessionConfig(baseConfig)}`;
+
+  const cachedSession = configuredSessionCache.get(cacheKey);
+  if (cachedSession) {
+    return cachedSession;
+  }
+
+  const weeklyLocalWindows = openWindows ? parseWeeklySessionWindows(openWindows) : baseConfig.weeklyLocalWindows;
+  const session = new WeeklyMarketSession({
+    timeZone,
+    weeklyLocalWindows,
+    label: baseConfig.label,
+  });
+  configuredSessionCache.set(cacheKey, session);
+  return session;
+}
 
 export function getConfiguredMarketSession(
   env: NodeJS.ProcessEnv = process.env,
   fallback: MarketSessionConfig = DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
 ): WeeklyMarketSession {
-  const profileName = env[MARKET_SESSION_PROFILE_ENV_VAR]?.trim() || null;
-  const profileConfig = profileName ? SESSION_PROFILES[profileName as keyof typeof SESSION_PROFILES] : null;
-  if (profileName && !profileConfig) {
-    throw new Error(
-      `Unknown ${MARKET_SESSION_PROFILE_ENV_VAR} "${profileName}". ` +
-        `Expected one of: ${Object.keys(SESSION_PROFILES).join(", ")}.`,
-    );
-  }
+  return getConfiguredMarketSessionForTicker("__default__", env, fallback);
+}
 
-  const baseConfig = profileConfig ?? fallback;
-  const timeZone = env[MARKET_SESSION_TIME_ZONE_ENV_VAR]?.trim() || baseConfig.timeZone;
-  const openWindows = env[MARKET_SESSION_OPEN_WINDOWS_ENV_VAR]?.trim();
-  const cacheKey = `${profileName ?? DEFAULT_MARKET_SESSION_PROFILE}||${timeZone}||${openWindows ?? ""}`;
-
-  if (cachedConfiguredSession && cachedConfiguredSessionKey === cacheKey) {
-    return cachedConfiguredSession;
-  }
-
-  const weeklyLocalWindows = openWindows ? parseWeeklySessionWindows(openWindows) : baseConfig.weeklyLocalWindows;
-
-  cachedConfiguredSession = new WeeklyMarketSession({
-    timeZone,
-    weeklyLocalWindows,
-    label: baseConfig.label,
-  });
-  cachedConfiguredSessionKey = cacheKey;
-  return cachedConfiguredSession;
+export function getConfiguredMarketSessionResolver(
+  env: NodeJS.ProcessEnv = process.env,
+  fallback: MarketSessionConfig = DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
+): MarketSessionResolver {
+  return (ticker: string) => getConfiguredMarketSessionForTicker(ticker, env, fallback);
 }
 
 export function isMarketOpenAt(date: Date, session: WeeklyMarketSession = getConfiguredMarketSession()): boolean {

--- a/apps/market-write-node/src/lib/trade/market-session.ts
+++ b/apps/market-write-node/src/lib/trade/market-session.ts
@@ -6,6 +6,12 @@
  * hardcoding UTC close/reopen hours that break during daylight saving changes.
  */
 
+import {
+  DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
+  MARKET_SESSION_OPEN_WINDOWS_ENV_VAR,
+  MARKET_SESSION_TIME_ZONE_ENV_VAR,
+} from "./market-session-config.js";
+
 const MINUTES_PER_DAY = 24 * 60;
 const MINUTES_PER_WEEK = 7 * MINUTES_PER_DAY;
 const SEARCH_WINDOW_MS = 36 * 60 * 60 * 1000;
@@ -70,17 +76,7 @@ export interface MarketSessionConfig {
   label?: string;
 }
 
-export const DEFAULT_GLOBEX_MARKET_SESSION_CONFIG: MarketSessionConfig = {
-  timeZone: "America/Chicago",
-  weeklyLocalWindows: [
-    { startDay: "Sun", startTime: "17:00", endDay: "Mon", endTime: "16:00" },
-    { startDay: "Mon", startTime: "17:00", endDay: "Tue", endTime: "16:00" },
-    { startDay: "Tue", startTime: "17:00", endDay: "Wed", endTime: "16:00" },
-    { startDay: "Wed", startTime: "17:00", endDay: "Thu", endTime: "16:00" },
-    { startDay: "Thu", startTime: "17:00", endDay: "Fri", endTime: "16:00" },
-  ],
-  label: "CME Globex",
-};
+export { DEFAULT_GLOBEX_MARKET_SESSION_CONFIG } from "./market-session-config.js";
 
 const zonedDateTimeFormatterCache = new Map<string, Intl.DateTimeFormat>();
 
@@ -436,7 +432,7 @@ export function parseWeeklySessionWindows(value: string): WeeklySessionWindowInp
       const match = /^([A-Za-z]{3})\s+(\d{2}:\d{2})\s*-\s*([A-Za-z]{3})\s+(\d{2}:\d{2})$/.exec(segment);
       if (!match) {
         throw new Error(
-          `Invalid MARKET_SESSION_OPEN_WINDOWS segment "${segment}". ` +
+          `Invalid ${MARKET_SESSION_OPEN_WINDOWS_ENV_VAR} segment "${segment}". ` +
             `Expected format like "Sun 17:00-Mon 16:00".`,
         );
       }
@@ -457,8 +453,8 @@ export function getConfiguredMarketSession(
   env: NodeJS.ProcessEnv = process.env,
   fallback: MarketSessionConfig = DEFAULT_GLOBEX_MARKET_SESSION_CONFIG,
 ): WeeklyMarketSession {
-  const timeZone = env.MARKET_SESSION_TIME_ZONE?.trim() || fallback.timeZone;
-  const openWindows = env.MARKET_SESSION_OPEN_WINDOWS?.trim();
+  const timeZone = env[MARKET_SESSION_TIME_ZONE_ENV_VAR]?.trim() || fallback.timeZone;
+  const openWindows = env[MARKET_SESSION_OPEN_WINDOWS_ENV_VAR]?.trim();
   const cacheKey = `${timeZone}||${openWindows ?? ""}`;
 
   if (cachedConfiguredSession && cachedConfiguredSessionKey === cacheKey) {

--- a/apps/market-write-node/src/lib/trade/rolling-candle-window.ts
+++ b/apps/market-write-node/src/lib/trade/rolling-candle-window.ts
@@ -3,6 +3,7 @@
  * already-finalized lower-timeframe candle rows.
  */
 
+import { collectOpenBucketTimesBetween, getConfiguredMarketSession, type WeeklyMarketSession } from "./market-session.js";
 import type { CandleForDb, CandleState } from "./types.js";
 
 interface TickerWindowState {
@@ -31,14 +32,15 @@ interface RollingCandleWindowOptions {
   windowSize: number;
   expectedIntervalMs: number;
   label: string;
+  sessionCalendar?: WeeklyMarketSession;
 }
 
 export class RollingCandleWindow {
   private readonly tickerStates = new Map<string, TickerWindowState>();
   private readonly windowSize: number;
   private readonly expectedIntervalMs: number;
-  private readonly windowSpanMs: number;
   private readonly label: string;
+  private readonly sessionCalendar: WeeklyMarketSession;
 
   private pendingCandles: CandleForDb[] = [];
   private stats = {
@@ -51,8 +53,8 @@ export class RollingCandleWindow {
   constructor(options: RollingCandleWindowOptions) {
     this.windowSize = options.windowSize;
     this.expectedIntervalMs = options.expectedIntervalMs;
-    this.windowSpanMs = (this.windowSize - 1) * this.expectedIntervalMs;
     this.label = options.label;
+    this.sessionCalendar = options.sessionCalendar ?? getConfiguredMarketSession();
   }
 
   seedCandles(candles: CandleForDb[]): void {
@@ -139,9 +141,19 @@ export class RollingCandleWindow {
       }
 
       if (deltaMs > this.expectedIntervalMs) {
-        state.ring = [];
-        state.warmupDone = false;
-        this.stats.gapResets++;
+        const firstMissingInputMs = state.lastInputMs + this.expectedIntervalMs;
+        const openGap = collectOpenBucketTimesBetween(
+          firstMissingInputMs,
+          inputTimeMs,
+          this.expectedIntervalMs,
+          0,
+          this.sessionCalendar,
+        );
+        if (openGap.exceeded) {
+          state.ring = [];
+          state.warmupDone = false;
+          this.stats.gapResets++;
+        }
       }
     }
 
@@ -149,8 +161,7 @@ export class RollingCandleWindow {
     state.lastInputMs = inputTimeMs;
     state.ring.push(input);
 
-    const cutoffMs = inputTimeMs - this.windowSpanMs;
-    while (state.ring.length > 0 && new Date(state.ring[0].time).getTime() < cutoffMs) {
+    while (state.ring.length > this.windowSize) {
       state.ring.shift();
     }
 

--- a/apps/market-write-node/src/lib/trade/rolling-candle-window.ts
+++ b/apps/market-write-node/src/lib/trade/rolling-candle-window.ts
@@ -3,7 +3,12 @@
  * already-finalized lower-timeframe candle rows.
  */
 
-import { collectOpenBucketTimesBetween, getConfiguredMarketSession, type WeeklyMarketSession } from "./market-session.js";
+import {
+  collectOpenBucketTimesBetween,
+  getConfiguredMarketSessionResolver,
+  type MarketSessionResolver,
+  type WeeklyMarketSession,
+} from "./market-session.js";
 import type { CandleForDb, CandleState } from "./types.js";
 
 interface TickerWindowState {
@@ -33,6 +38,7 @@ interface RollingCandleWindowOptions {
   expectedIntervalMs: number;
   label: string;
   sessionCalendar?: WeeklyMarketSession;
+  sessionCalendarResolver?: MarketSessionResolver;
 }
 
 export class RollingCandleWindow {
@@ -40,7 +46,7 @@ export class RollingCandleWindow {
   private readonly windowSize: number;
   private readonly expectedIntervalMs: number;
   private readonly label: string;
-  private readonly sessionCalendar: WeeklyMarketSession;
+  private readonly sessionCalendarResolver: MarketSessionResolver;
 
   private pendingCandles: CandleForDb[] = [];
   private stats = {
@@ -54,7 +60,9 @@ export class RollingCandleWindow {
     this.windowSize = options.windowSize;
     this.expectedIntervalMs = options.expectedIntervalMs;
     this.label = options.label;
-    this.sessionCalendar = options.sessionCalendar ?? getConfiguredMarketSession();
+    this.sessionCalendarResolver =
+      options.sessionCalendarResolver ??
+      (options.sessionCalendar ? () => options.sessionCalendar! : getConfiguredMarketSessionResolver());
   }
 
   seedCandles(candles: CandleForDb[]): void {
@@ -147,7 +155,7 @@ export class RollingCandleWindow {
           inputTimeMs,
           this.expectedIntervalMs,
           0,
-          this.sessionCalendar,
+          this.sessionCalendarResolver(input.ticker),
         );
         if (openGap.exceeded) {
           state.ring = [];

--- a/apps/market-write-node/src/lib/trade/rolling-session-continuity.test.ts
+++ b/apps/market-write-node/src/lib/trade/rolling-session-continuity.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { DEFAULT_GLOBEX_MARKET_SESSION_CONFIG, WeeklyMarketSession } from "./market-session.js";
+import { RollingCandleWindow } from "./rolling-candle-window.js";
+import { RollingWindow1m } from "./rolling-window.js";
+import type { CandleForDb, CandleState, NormalizedTrade } from "./types.js";
+
+const globexSession = new WeeklyMarketSession(DEFAULT_GLOBEX_MARKET_SESSION_CONFIG);
+const tokyoSession = new WeeklyMarketSession({
+  timeZone: "Asia/Tokyo",
+  weeklyLocalWindows: [
+    { startDay: "Mon", startTime: "09:00", endDay: "Mon", endTime: "11:30" },
+    { startDay: "Mon", startTime: "12:30", endDay: "Mon", endTime: "15:00" },
+  ],
+  label: "Tokyo daytime",
+});
+
+function makeTrade(symbol: string, price: number): NormalizedTrade {
+  return {
+    ticker: "ES",
+    symbol,
+    price,
+    size: 1,
+    isAsk: true,
+    isBid: false,
+    bidPrice: price - 0.25,
+    askPrice: price + 0.25,
+    bidSize: 10,
+    askSize: 10,
+  };
+}
+
+function addTrade(window: RollingWindow1m, symbol: string, isoTime: string, price: number): void {
+  window.addTrade({
+    trade: makeTrade(symbol, price),
+    secondBucket: isoTime,
+    minuteBucket: isoTime.slice(0, 16) + ":00.000Z",
+  });
+}
+
+function makeCandleForDb(time: string, price: number): CandleForDb {
+  const candle: CandleState = {
+    open: price,
+    high: price,
+    low: price,
+    close: price,
+    volume: 1,
+    askVolume: 1,
+    bidVolume: 0,
+    unknownSideVolume: 0,
+    sumBidDepth: 10,
+    sumAskDepth: 10,
+    sumSpread: 0,
+    sumMidPrice: price,
+    sumPriceVolume: price,
+    maxTradeSize: 1,
+    largeTradeCount: 0,
+    largeTradeVolume: 0,
+    tradeCount: 1,
+    symbol: "ESH6",
+    currentCvd: 1,
+    metricsOHLC: {
+      cvd: {
+        open: 1,
+        high: 1,
+        low: 1,
+        close: 1,
+      },
+    },
+  };
+
+  return {
+    key: `ES|${time}`,
+    ticker: "ES",
+    time,
+    candle,
+  };
+}
+
+test("1m rolling VWAP accumulator stays continuous across summer Globex maintenance", () => {
+  const window = new RollingWindow1m({
+    windowSeconds: 3,
+    maxSyntheticGapSeconds: 5,
+    sessionCalendar: globexSession,
+  });
+
+  addTrade(window, "ESH6", "2026-03-09T20:59:57.000Z", 100);
+  addTrade(window, "ESH6", "2026-03-09T20:59:58.000Z", 101);
+  addTrade(window, "ESH6", "2026-03-09T20:59:59.000Z", 102);
+  addTrade(window, "ESH6", "2026-03-09T22:00:00.000Z", 103);
+  window.finalizeAll();
+
+  const reopenCandle = window.drainPendingCandles().at(-1);
+  assert.ok(reopenCandle);
+  assert.equal(reopenCandle.time, "2026-03-09T22:00:00.000Z");
+  assert.equal(reopenCandle.candle.volume, 3);
+  assert.equal(reopenCandle.candle.sumPriceVolume, 306);
+  assert.equal(reopenCandle.candle.open, 101);
+  assert.equal(reopenCandle.candle.close, 103);
+  assert.equal(window.getStats().gapResets, 0);
+});
+
+test("1h rolling VWAP accumulator stays continuous across summer Globex maintenance", () => {
+  const window = new RollingCandleWindow({
+    windowSize: 3,
+    expectedIntervalMs: 60_000,
+    label: "1h@1m",
+    sessionCalendar: globexSession,
+  });
+
+  window.addCandles([
+    makeCandleForDb("2026-03-09T20:57:00.000Z", 100),
+    makeCandleForDb("2026-03-09T20:58:00.000Z", 101),
+    makeCandleForDb("2026-03-09T20:59:00.000Z", 102),
+    makeCandleForDb("2026-03-09T22:00:00.000Z", 103),
+  ]);
+
+  const reopenCandle = window.drainPendingCandles().at(-1);
+  assert.ok(reopenCandle);
+  assert.equal(reopenCandle.time, "2026-03-09T22:00:00.000Z");
+  assert.equal(reopenCandle.candle.volume, 3);
+  assert.equal(reopenCandle.candle.sumPriceVolume, 306);
+  assert.equal(reopenCandle.candle.open, 101);
+  assert.equal(reopenCandle.candle.close, 103);
+  assert.equal(window.getStats().gapResets, 0);
+});
+
+test("rolling continuity works with a non-US session calendar", () => {
+  const window = new RollingWindow1m({
+    windowSeconds: 3,
+    maxSyntheticGapSeconds: 5,
+    sessionCalendar: tokyoSession,
+  });
+
+  addTrade(window, "ESH6", "2026-01-05T02:29:57.000Z", 100);
+  addTrade(window, "ESH6", "2026-01-05T02:29:58.000Z", 101);
+  addTrade(window, "ESH6", "2026-01-05T02:29:59.000Z", 102);
+  addTrade(window, "ESH6", "2026-01-05T03:30:00.000Z", 103);
+  window.finalizeAll();
+
+  const reopenCandle = window.drainPendingCandles().at(-1);
+  assert.ok(reopenCandle);
+  assert.equal(reopenCandle.time, "2026-01-05T03:30:00.000Z");
+  assert.equal(reopenCandle.candle.volume, 3);
+  assert.equal(reopenCandle.candle.sumPriceVolume, 306);
+  assert.equal(window.getStats().gapResets, 0);
+});

--- a/apps/market-write-node/src/lib/trade/rolling-session-continuity.test.ts
+++ b/apps/market-write-node/src/lib/trade/rolling-session-continuity.test.ts
@@ -2,9 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { DEFAULT_GLOBEX_MARKET_SESSION_CONFIG, SESSION_PROFILES } from "./market-session-config.js";
-import { WeeklyMarketSession } from "./market-session.js";
+import { getConfiguredMarketSessionForTicker, WeeklyMarketSession } from "./market-session.js";
 import { RollingCandleWindow } from "./rolling-candle-window.js";
 import { RollingWindow1m } from "./rolling-window.js";
+import { extractTicker } from "./symbol.js";
 import type { CandleForDb, CandleState, NormalizedTrade } from "./types.js";
 
 const globexSession = new WeeklyMarketSession(DEFAULT_GLOBEX_MARKET_SESSION_CONFIG);
@@ -12,7 +13,7 @@ const tokyoSession = new WeeklyMarketSession(SESSION_PROFILES.tokyo_daytime);
 
 function makeTrade(symbol: string, price: number): NormalizedTrade {
   return {
-    ticker: "ES",
+    ticker: extractTicker(symbol),
     symbol,
     price,
     size: 1,
@@ -138,5 +139,41 @@ test("rolling continuity works with a non-US session calendar", () => {
   assert.equal(reopenCandle.time, "2026-01-05T03:30:00.000Z");
   assert.equal(reopenCandle.candle.volume, 3);
   assert.equal(reopenCandle.candle.sumPriceVolume, 306);
+  assert.equal(window.getStats().gapResets, 0);
+});
+
+test("rolling window can resolve different session calendars per ticker", () => {
+  const window = new RollingWindow1m({
+    windowSeconds: 3,
+    maxSyntheticGapSeconds: 5,
+    sessionCalendarResolver: (ticker) => getConfiguredMarketSessionForTicker(ticker),
+  });
+
+  addTrade(window, "ESH6", "2026-03-09T20:59:57.000Z", 100);
+  addTrade(window, "ESH6", "2026-03-09T20:59:58.000Z", 101);
+  addTrade(window, "ESH6", "2026-03-09T20:59:59.000Z", 102);
+  addTrade(window, "ESH6", "2026-03-09T22:00:00.000Z", 103);
+
+  addTrade(window, "NKH6", "2026-01-05T02:29:57.000Z", 200);
+  addTrade(window, "NKH6", "2026-01-05T02:29:58.000Z", 201);
+  addTrade(window, "NKH6", "2026-01-05T02:29:59.000Z", 202);
+  addTrade(window, "NKH6", "2026-01-05T03:30:00.000Z", 203);
+  window.finalizeAll();
+
+  const candlesByTicker = window.drainPendingCandles().reduce<Record<string, CandleForDb[]>>((grouped, candle) => {
+    grouped[candle.ticker] ??= [];
+    grouped[candle.ticker].push(candle);
+    return grouped;
+  }, {});
+  const esReopen = candlesByTicker.ES?.at(-1);
+  const nkReopen = candlesByTicker.NK?.at(-1);
+
+  assert.ok(esReopen);
+  assert.equal(esReopen.time, "2026-03-09T22:00:00.000Z");
+  assert.equal(esReopen.candle.sumPriceVolume, 306);
+
+  assert.ok(nkReopen);
+  assert.equal(nkReopen.time, "2026-01-05T03:30:00.000Z");
+  assert.equal(nkReopen.candle.sumPriceVolume, 606);
   assert.equal(window.getStats().gapResets, 0);
 });

--- a/apps/market-write-node/src/lib/trade/rolling-session-continuity.test.ts
+++ b/apps/market-write-node/src/lib/trade/rolling-session-continuity.test.ts
@@ -1,21 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { DEFAULT_GLOBEX_MARKET_SESSION_CONFIG } from "./market-session-config.js";
+import { DEFAULT_GLOBEX_MARKET_SESSION_CONFIG, SESSION_PROFILES } from "./market-session-config.js";
 import { WeeklyMarketSession } from "./market-session.js";
 import { RollingCandleWindow } from "./rolling-candle-window.js";
 import { RollingWindow1m } from "./rolling-window.js";
 import type { CandleForDb, CandleState, NormalizedTrade } from "./types.js";
 
 const globexSession = new WeeklyMarketSession(DEFAULT_GLOBEX_MARKET_SESSION_CONFIG);
-const tokyoSession = new WeeklyMarketSession({
-  timeZone: "Asia/Tokyo",
-  weeklyLocalWindows: [
-    { startDay: "Mon", startTime: "09:00", endDay: "Mon", endTime: "11:30" },
-    { startDay: "Mon", startTime: "12:30", endDay: "Mon", endTime: "15:00" },
-  ],
-  label: "Tokyo daytime",
-});
+const tokyoSession = new WeeklyMarketSession(SESSION_PROFILES.tokyo_daytime);
 
 function makeTrade(symbol: string, price: number): NormalizedTrade {
   return {

--- a/apps/market-write-node/src/lib/trade/rolling-session-continuity.test.ts
+++ b/apps/market-write-node/src/lib/trade/rolling-session-continuity.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { DEFAULT_GLOBEX_MARKET_SESSION_CONFIG, WeeklyMarketSession } from "./market-session.js";
+import { DEFAULT_GLOBEX_MARKET_SESSION_CONFIG } from "./market-session-config.js";
+import { WeeklyMarketSession } from "./market-session.js";
 import { RollingCandleWindow } from "./rolling-candle-window.js";
 import { RollingWindow1m } from "./rolling-window.js";
 import type { CandleForDb, CandleState, NormalizedTrade } from "./types.js";

--- a/apps/market-write-node/src/lib/trade/rolling-window.ts
+++ b/apps/market-write-node/src/lib/trade/rolling-window.ts
@@ -8,6 +8,7 @@
 
 import { createCandleFromTrade, updateCandleCvdOHLC, updateCandleWithTrade } from "./candle-aggregation.js";
 import { FrontMonthTracker } from "./front-month.js";
+import { collectOpenBucketTimesBetween, getConfiguredMarketSession, type WeeklyMarketSession } from "./market-session.js";
 import type { CandleForDb, CandleState, MetricCalculationContext, NormalizedTrade } from "./types.js";
 
 interface SecondSummary {
@@ -77,12 +78,19 @@ export interface RollingWindowStats {
 const DEFAULT_WINDOW_SECONDS = 60;
 const DEFAULT_MAX_SYNTHETIC_GAP_SECONDS = 5 * 60;
 
+interface RollingWindow1mOptions {
+  windowSeconds?: number;
+  maxSyntheticGapSeconds?: number;
+  tracker?: FrontMonthTracker;
+  sessionCalendar?: WeeklyMarketSession;
+}
+
 export class RollingWindow1m {
   private readonly tickerStates = new Map<string, TickerRollingState>();
   private readonly tracker: FrontMonthTracker;
   private readonly windowSeconds: number;
-  private readonly windowSpanMs: number;
   private readonly maxSyntheticGapSeconds: number;
+  private readonly sessionCalendar: WeeklyMarketSession;
 
   private pendingCandles: CandleForDb[] = [];
   private secondsProcessed = 0;
@@ -91,11 +99,11 @@ export class RollingWindow1m {
   private gapResets = 0;
   private outOfOrderTradesIgnored = 0;
 
-  constructor(options?: { windowSeconds?: number; maxSyntheticGapSeconds?: number; tracker?: FrontMonthTracker }) {
+  constructor(options?: RollingWindow1mOptions) {
     this.windowSeconds = options?.windowSeconds ?? DEFAULT_WINDOW_SECONDS;
-    this.windowSpanMs = (this.windowSeconds - 1) * 1000;
     this.maxSyntheticGapSeconds = options?.maxSyntheticGapSeconds ?? DEFAULT_MAX_SYNTHETIC_GAP_SECONDS;
     this.tracker = options?.tracker ?? new FrontMonthTracker();
+    this.sessionCalendar = options?.sessionCalendar ?? getConfiguredMarketSession();
   }
 
   seedTickerCvd(ticker: string, cvd: number): void {
@@ -370,13 +378,19 @@ export class RollingWindow1m {
       return;
     }
 
-    const missingSeconds = Math.floor((targetSecondMsExclusive - firstMissingSecondMs) / 1000);
-    if (missingSeconds > this.maxSyntheticGapSeconds) {
-      this.resetTickerGapState(ticker, state, missingSeconds);
+    const openGap = collectOpenBucketTimesBetween(
+      firstMissingSecondMs,
+      targetSecondMsExclusive,
+      1000,
+      this.maxSyntheticGapSeconds,
+      this.sessionCalendar,
+    );
+    if (openGap.exceeded) {
+      this.resetTickerGapState(ticker, state, openGap.openBucketCount);
       return;
     }
 
-    for (let timeMs = firstMissingSecondMs; timeMs < targetSecondMsExclusive; timeMs += 1000) {
+    for (const timeMs of openGap.bucketTimes) {
       const summary = this.createSyntheticSecondSummary(state.lastSummary, timeMs);
       this.syntheticSecondsFilled++;
       this.processCompletedSummary(ticker, state, summary);
@@ -422,13 +436,8 @@ export class RollingWindow1m {
     this.secondsProcessed++;
     state.warmupSecondsCollected++;
 
-    const cutoffMs = summary.timeMs - this.windowSpanMs;
-    let pruneIdx = 0;
-    while (pruneIdx < state.ring.length && state.ring[pruneIdx].timeMs < cutoffMs) {
-      pruneIdx++;
-    }
-    if (pruneIdx > 0) {
-      state.ring = state.ring.slice(pruneIdx);
+    while (state.ring.length > this.windowSeconds) {
+      state.ring.shift();
     }
 
     if (state.ring.length === 0) {
@@ -457,7 +466,7 @@ export class RollingWindow1m {
     });
   }
 
-  private resetTickerGapState(ticker: string, state: TickerRollingState, missingSeconds: number): void {
+  private resetTickerGapState(ticker: string, state: TickerRollingState, missingOpenSeconds: number): void {
     state.ring = [];
     state.currentCandle = null;
     state.currentSecondBucket = null;
@@ -466,7 +475,7 @@ export class RollingWindow1m {
     state.lastSummary = null;
     this.gapResets++;
     console.log(
-      `⏭️ Reset rolling 1m state for ${ticker} after ${missingSeconds}s gap ` +
+      `⏭️ Reset rolling 1m state for ${ticker} after ${missingOpenSeconds}s open-market gap ` +
         `(max synthetic fill ${this.maxSyntheticGapSeconds}s)`,
     );
   }

--- a/apps/market-write-node/src/lib/trade/rolling-window.ts
+++ b/apps/market-write-node/src/lib/trade/rolling-window.ts
@@ -8,7 +8,12 @@
 
 import { createCandleFromTrade, updateCandleCvdOHLC, updateCandleWithTrade } from "./candle-aggregation.js";
 import { FrontMonthTracker } from "./front-month.js";
-import { collectOpenBucketTimesBetween, getConfiguredMarketSession, type WeeklyMarketSession } from "./market-session.js";
+import {
+  collectOpenBucketTimesBetween,
+  getConfiguredMarketSessionResolver,
+  type MarketSessionResolver,
+  type WeeklyMarketSession,
+} from "./market-session.js";
 import type { CandleForDb, CandleState, MetricCalculationContext, NormalizedTrade } from "./types.js";
 
 interface SecondSummary {
@@ -83,6 +88,7 @@ interface RollingWindow1mOptions {
   maxSyntheticGapSeconds?: number;
   tracker?: FrontMonthTracker;
   sessionCalendar?: WeeklyMarketSession;
+  sessionCalendarResolver?: MarketSessionResolver;
 }
 
 export class RollingWindow1m {
@@ -90,7 +96,7 @@ export class RollingWindow1m {
   private readonly tracker: FrontMonthTracker;
   private readonly windowSeconds: number;
   private readonly maxSyntheticGapSeconds: number;
-  private readonly sessionCalendar: WeeklyMarketSession;
+  private readonly sessionCalendarResolver: MarketSessionResolver;
 
   private pendingCandles: CandleForDb[] = [];
   private secondsProcessed = 0;
@@ -103,7 +109,9 @@ export class RollingWindow1m {
     this.windowSeconds = options?.windowSeconds ?? DEFAULT_WINDOW_SECONDS;
     this.maxSyntheticGapSeconds = options?.maxSyntheticGapSeconds ?? DEFAULT_MAX_SYNTHETIC_GAP_SECONDS;
     this.tracker = options?.tracker ?? new FrontMonthTracker();
-    this.sessionCalendar = options?.sessionCalendar ?? getConfiguredMarketSession();
+    this.sessionCalendarResolver =
+      options?.sessionCalendarResolver ??
+      (options?.sessionCalendar ? () => options.sessionCalendar! : getConfiguredMarketSessionResolver());
   }
 
   seedTickerCvd(ticker: string, cvd: number): void {
@@ -383,7 +391,7 @@ export class RollingWindow1m {
       targetSecondMsExclusive,
       1000,
       this.maxSyntheticGapSeconds,
-      this.sessionCalendar,
+      this.sessionCalendarResolver(ticker),
     );
     if (openGap.exceeded) {
       this.resetTickerGapState(ticker, state, openGap.openBucketCount);

--- a/apps/market-write-node/src/stream/AGENTS.md
+++ b/apps/market-write-node/src/stream/AGENTS.md
@@ -15,7 +15,7 @@ downstream feature-engineering or ML-specific logic.
   - Parses newline-delimited JSON messages from the socket
   - Builds an instrument_id-to-symbol lookup from symbol mapping messages (rtype=22)
   - Converts trade messages (action="T") into `TbboRecord` objects
-  - Skips spread contracts (symbols containing "-") and trades during market closed hours
+  - Skips spread contracts (symbols containing "-") and gates trades by the configured session calendar using the trade event timestamp
   - Passes each valid trade to the aggregator
 
 - **`tbbo-1m-aggregator.ts`** is the live wrapper around the shared rolling-window engine
@@ -56,6 +56,8 @@ Environment variables (all required):
 | `DATABENTO_SYMBOLS` | `ES.FUT,NQ.FUT`  | Comma-separated symbols               |
 | `DATABENTO_STYPE`   | `parent`         | Symbol type: `parent` or `raw_symbol` |
 | `TIMESCALE_URL`     | `postgres://...` | TimescaleDB connection                |
+| `MARKET_SESSION_TIME_ZONE` | `America/Chicago` | Optional IANA time zone for the trading session |
+| `MARKET_SESSION_OPEN_WINDOWS` | `Sun 17:00-Mon 16:00, ...` | Optional weekly open windows in local session time |
 
 ## Shared Libraries
 
@@ -70,7 +72,7 @@ Stream-specific code should only handle:
 - TCP connection lifecycle
 - Databento protocol details
 - JSON parsing and symbol mapping
-- market-hours gating
+- session-calendar gating
 - retry / timer orchestration
 
 ## Roadmap

--- a/apps/market-write-node/src/stream/tbbo-stream.ts
+++ b/apps/market-write-node/src/stream/tbbo-stream.ts
@@ -10,6 +10,7 @@
 
 import { createConnection, Socket } from "net";
 import { createHash } from "crypto";
+import { getConfiguredMarketSession, isMarketOpenAt, toSecondBucket } from "../lib/trade/index.js";
 import { Tbbo1mAggregator, TbboRecord } from "./tbbo-1m-aggregator.js";
 
 // Configuration from environment (all required - no defaults)
@@ -24,44 +25,14 @@ const DATABENTO_STYPE = process.env.DATABENTO_STYPE;
 // Reconnection settings
 const MAX_RECONNECT_DELAY = 30000;
 const INITIAL_RECONNECT_DELAY = 1000;
+const marketSession = getConfiguredMarketSession();
 
-/**
- * Check if futures market is currently open
- *
- * Futures market closed hours (all times in UTC):
- * - All days: 22:00 - 22:59 (daily maintenance window)
- * - Friday: 22:00 - 24:00 (weekend close starts)
- * - Saturday: all day (closed)
- * - Sunday: 0:00 - 22:59 (closed until market opens at 23:00)
- *
- * @returns true if market is open, false if closed
- */
 function isFuturesMarketOpen(): boolean {
-  const now = new Date();
-  const utcDay = now.getUTCDay(); // 0 = Sunday, 5 = Friday, 6 = Saturday
-  const utcHour = now.getUTCHours();
+  return isMarketOpenAt(new Date(), marketSession);
+}
 
-  // Saturday: all day closed
-  if (utcDay === 6) {
-    return false;
-  }
-
-  // Sunday: closed 0:00 - 22:59, opens at 23:00
-  if (utcDay === 0 && utcHour < 23) {
-    return false;
-  }
-
-  // Friday: closed from 22:00 onward (until Sunday 23:00)
-  if (utcDay === 5 && utcHour >= 22) {
-    return false;
-  }
-
-  // All other days (Mon-Thu, and Sun after 23:00): closed 22:00 - 22:59
-  if (utcHour === 22) {
-    return false;
-  }
-
-  return true;
+function isRecordDuringOpenSession(record: TbboRecord): boolean {
+  return isMarketOpenAt(new Date(toSecondBucket(record.timestamp)), marketSession);
 }
 
 // Track skipped records due to market closed
@@ -388,8 +359,8 @@ function handleData(data: Buffer): void {
       // After session starts, messages are JSON records
       const record = parseTbboRecord(message);
       if (record && state.aggregator) {
-        // Check if futures market is open before processing
-        if (!isFuturesMarketOpen()) {
+        // Gate live ingestion by the trade's event timestamp in the configured session calendar.
+        if (!isRecordDuringOpenSession(record)) {
           skippedMarketClosed++;
           // Log market closed status periodically (every 5 minutes)
           const now = Date.now();
@@ -568,6 +539,7 @@ export async function startDatabentoStream(): Promise<void> {
   console.log(`   Symbols: ${DATABENTO_SYMBOLS!.join(", ")}`);
   console.log(`   Symbol Type: ${DATABENTO_STYPE}`);
   console.log(`   Schema: TBBO (Top of Book on Trade)`);
+  console.log(`   Session: ${marketSession.describe()}`);
   console.log(`   API Key: ${apiKeyPreview}`);
   console.log("═".repeat(50));
 

--- a/apps/market-write-node/src/stream/tbbo-stream.ts
+++ b/apps/market-write-node/src/stream/tbbo-stream.ts
@@ -10,7 +10,13 @@
 
 import { createConnection, Socket } from "net";
 import { createHash } from "crypto";
-import { getConfiguredMarketSession, isMarketOpenAt, toSecondBucket } from "../lib/trade/index.js";
+import {
+  extractTicker,
+  getConfiguredMarketSessionForTicker,
+  getConfiguredMarketSessionResolver,
+  isMarketOpenAt,
+  toSecondBucket,
+} from "../lib/trade/index.js";
 import { Tbbo1mAggregator, TbboRecord } from "./tbbo-1m-aggregator.js";
 
 // Configuration from environment (all required - no defaults)
@@ -25,14 +31,27 @@ const DATABENTO_STYPE = process.env.DATABENTO_STYPE;
 // Reconnection settings
 const MAX_RECONNECT_DELAY = 30000;
 const INITIAL_RECONNECT_DELAY = 1000;
-const marketSession = getConfiguredMarketSession();
+const marketSessionResolver = getConfiguredMarketSessionResolver();
+
+function getConfiguredSymbolTicker(symbol: string): string {
+  if (symbol.includes(".")) {
+    return symbol.split(".")[0];
+  }
+  return extractTicker(symbol);
+}
 
 function isFuturesMarketOpen(): boolean {
-  return isMarketOpenAt(new Date(), marketSession);
+  const configuredTickers = DATABENTO_SYMBOLS?.map(getConfiguredSymbolTicker) ?? [];
+  if (configuredTickers.length === 0) {
+    return isMarketOpenAt(new Date(), getConfiguredMarketSessionForTicker("__default__"));
+  }
+
+  return configuredTickers.some((ticker) => isMarketOpenAt(new Date(), marketSessionResolver(ticker)));
 }
 
 function isRecordDuringOpenSession(record: TbboRecord): boolean {
-  return isMarketOpenAt(new Date(toSecondBucket(record.timestamp)), marketSession);
+  const ticker = extractTicker(record.symbol);
+  return isMarketOpenAt(new Date(toSecondBucket(record.timestamp)), marketSessionResolver(ticker));
 }
 
 // Track skipped records due to market closed
@@ -318,7 +337,13 @@ export function getStreamStats(): {
   parseErrors: number;
   symbolMappings: Record<string, number>;
   marketOpen: boolean;
+  marketOpenByTicker: Record<string, boolean>;
 } {
+  const configuredTickers = [...new Set((DATABENTO_SYMBOLS?.map(getConfiguredSymbolTicker) ?? []).filter(Boolean))];
+  const marketOpenByTicker = Object.fromEntries(
+    configuredTickers.map((ticker) => [ticker, isMarketOpenAt(new Date(), marketSessionResolver(ticker))]),
+  );
+
   return {
     messagesReceived: messageCount,
     skippedControlMessages,
@@ -329,6 +354,7 @@ export function getStreamStats(): {
     parseErrors,
     symbolMappings: Object.fromEntries(symbolToInstrumentId),
     marketOpen: isFuturesMarketOpen(),
+    marketOpenByTicker,
   };
 }
 
@@ -539,7 +565,10 @@ export async function startDatabentoStream(): Promise<void> {
   console.log(`   Symbols: ${DATABENTO_SYMBOLS!.join(", ")}`);
   console.log(`   Symbol Type: ${DATABENTO_STYPE}`);
   console.log(`   Schema: TBBO (Top of Book on Trade)`);
-  console.log(`   Session: ${marketSession.describe()}`);
+  const configuredSessions = [...new Set(DATABENTO_SYMBOLS!.map(getConfiguredSymbolTicker))]
+    .map((ticker) => `${ticker} -> ${marketSessionResolver(ticker).describe()}`)
+    .join(" | ");
+  console.log(`   Sessions: ${configuredSessions}`);
   console.log(`   API Key: ${apiKeyPreview}`);
   console.log("═".repeat(50));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- rewrite the VWAP continuity change onto a fresh branch with a time-zone-aware session calendar
- replace fixed UTC market-hours logic with reusable weekly local session windows in any IANA time zone
- externalize the default Globex session profile into a dedicated constants file for easier incremental market/session updates
- add a small named `SESSION_PROFILES` map and support selecting a profile via `MARKET_SESSION_PROFILE`
- add per-ticker session-profile resolution so live trades and historical files can use different calendars in the same process
- preserve rolling VWAP/CVD continuity across scheduled closures while still resetting on true open-market gaps
- gate live trades by event timestamp instead of wall-clock processing time
- add DST and non-US session coverage in unit tests and update docs/config guidance

## Testing
- `pnpm --filter market-write-node build`
- `pnpm --filter market-write-node exec node --import tsx --test src/lib/trade/market-session.test.ts src/lib/trade/rolling-session-continuity.test.ts`
- `pnpm build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50040abf-c5c5-4b7e-ac8b-a106ef539fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50040abf-c5c5-4b7e-ac8b-a106ef539fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

