### PR TITLE
Fix hourly candle reconciliation and retry durability

### DIFF
--- a/apps/market-write-node/scripts/candles-1h-1m.ts
+++ b/apps/market-write-node/scripts/candles-1h-1m.ts
@@ -121,7 +121,7 @@ async function processHistoricalBaseRows(): Promise<void> {
     stats.pagesRead++;
     stats.sourceRowsRead += rows.length;
 
-    const candles = rows.map(candleForDbFromStoredRow);
+    const candles = rows.map((row) => candleForDbFromStoredRow(row, { requireCompleteCvd: true }));
     rollingWindow.addCandles(candles);
 
     if (rollingWindow.getStats().pendingCandles >= FLUSH_THRESHOLD) {

--- a/apps/market-write-node/src/lib/trade/canonical-candle.test.ts
+++ b/apps/market-write-node/src/lib/trade/canonical-candle.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { StoredCandleRow } from "./canonical-candle.js";
+import { candleForDbFromStoredRow } from "./canonical-candle.js";
+
+function makeStoredRow(): StoredCandleRow {
+  return {
+    time: "2026-03-10T14:00:00.000Z",
+    ticker: "ES",
+    symbol: "ESH6",
+    open: 6000,
+    high: 6001,
+    low: 5999,
+    close: 6000.5,
+    volume: 10,
+    ask_volume: 6,
+    bid_volume: 4,
+    cvd_open: 100,
+    cvd_high: 105,
+    cvd_low: 99,
+    cvd_close: 102,
+    trades: 10,
+    max_trade_size: 3,
+    big_trades: 0,
+    big_volume: 0,
+    vd: 2,
+    vd_ratio: 0.2,
+    book_imbalance: 0,
+    price_pct: 0,
+    divergence: 0,
+    sum_bid_depth: 10,
+    sum_ask_depth: 12,
+    sum_price_volume: 60005,
+    unknown_volume: 0,
+  };
+}
+
+test("rejects incomplete CVD OHLC when canonical source rows must be complete", () => {
+  const invalidRow: StoredCandleRow = {
+    ...makeStoredRow(),
+    cvd_high: null,
+  };
+
+  assert.throws(
+    () => candleForDbFromStoredRow(invalidRow, { requireCompleteCvd: true }),
+    /missing complete CVD OHLC/i,
+  );
+});

--- a/apps/market-write-node/src/lib/trade/canonical-candle.ts
+++ b/apps/market-write-node/src/lib/trade/canonical-candle.ts
@@ -42,7 +42,26 @@ function toIsoString(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
 }
 
-export function candleStateFromStoredRow(row: StoredCandleRow): CandleState {
+interface StoredRowConversionOptions {
+  requireCompleteCvd?: boolean;
+}
+
+function assertCompleteCvd(row: StoredCandleRow): void {
+  if (row.cvd_open !== null && row.cvd_high !== null && row.cvd_low !== null && row.cvd_close !== null) {
+    return;
+  }
+
+  throw new Error(
+    `Stored candle row for ${row.ticker} at ${toIsoString(row.time)} is missing complete CVD OHLC ` +
+      `and cannot be used as canonical hourly source data`,
+  );
+}
+
+export function candleStateFromStoredRow(row: StoredCandleRow, options: StoredRowConversionOptions = {}): CandleState {
+  if (options.requireCompleteCvd) {
+    assertCompleteCvd(row);
+  }
+
   const cvdOpen = row.cvd_open === null ? null : toNumber(row.cvd_open);
   const cvdHigh = row.cvd_high === null ? null : toNumber(row.cvd_high);
   const cvdLow = row.cvd_low === null ? null : toNumber(row.cvd_low);
@@ -82,13 +101,13 @@ export function candleStateFromStoredRow(row: StoredCandleRow): CandleState {
   };
 }
 
-export function candleForDbFromStoredRow(row: StoredCandleRow): CandleForDb {
+export function candleForDbFromStoredRow(row: StoredCandleRow, options: StoredRowConversionOptions = {}): CandleForDb {
   const time = toIsoString(row.time);
 
   return {
     key: `${row.ticker}|${time}`,
     ticker: row.ticker,
     time,
-    candle: candleStateFromStoredRow(row),
+    candle: candleStateFromStoredRow(row, options),
   };
 }

--- a/apps/market-write-node/src/stream/candles-1h-1m-aggregator.test.ts
+++ b/apps/market-write-node/src/stream/candles-1h-1m-aggregator.test.ts
@@ -11,7 +11,7 @@ const { Candles1h1mAggregator } = await import("./candles-1h-1m-aggregator.js");
 const BASE_TIME_MS = Date.parse("2026-03-10T14:00:00.000Z");
 
 function isLatestTargetQuery(text: string): boolean {
-  return text.includes("MAX(time) AS latest_target_time") && text.includes("FROM candles_1h_1m");
+  return text.includes("SELECT DISTINCT ON (ticker)") && text.includes("FROM candles_1h_1m");
 }
 
 function isHydrationQuery(text: string): boolean {
@@ -162,6 +162,7 @@ test("reconciles missing hourly rows from canonical 1m source on startup", async
     latest_target_time: minuteIso(59),
   }));
   const writtenTimes: string[] = [];
+  let reconciliationQueryCount = 0;
 
   const aggregator = new Candles1h1mAggregator({
     queryable: {
@@ -177,7 +178,10 @@ test("reconciles missing hourly rows from canonical 1m source on startup", async
         }
 
         if (isReconciliationQuery(text)) {
-          return { rows: reconciliationRows as Row[] };
+          reconciliationQueryCount++;
+          return {
+            rows: (reconciliationQueryCount === 1 ? reconciliationRows : []) as Row[],
+          };
         }
 
         throw new Error(`Unexpected query: ${text}`);

--- a/apps/market-write-node/src/stream/candles-1h-1m-aggregator.test.ts
+++ b/apps/market-write-node/src/stream/candles-1h-1m-aggregator.test.ts
@@ -10,6 +10,18 @@ const { Candles1h1mAggregator } = await import("./candles-1h-1m-aggregator.js");
 
 const BASE_TIME_MS = Date.parse("2026-03-10T14:00:00.000Z");
 
+function isLatestTargetQuery(text: string): boolean {
+  return text.includes("MAX(time) AS latest_target_time") && text.includes("FROM candles_1h_1m");
+}
+
+function isHydrationQuery(text: string): boolean {
+  return text.includes("ROW_NUMBER() OVER") && text.includes("FROM candles_1m_1s");
+}
+
+function isReconciliationQuery(text: string): boolean {
+  return text.includes("WITH latest_target(ticker, latest_target_time)");
+}
+
 function minuteIso(offset: number): string {
   return new Date(BASE_TIME_MS + offset * 60_000).toISOString();
 }
@@ -62,9 +74,21 @@ test("requeues hourly candles after transient write failure", async () => {
 
   const aggregator = new Candles1h1mAggregator({
     queryable: {
-      query: async <Row = unknown>(_text: string, _values?: unknown[]) => {
-        hydrationQueries++;
-        return { rows: seedRows as Row[] };
+      query: async <Row = unknown>(text: string, _values?: unknown[]) => {
+        if (isLatestTargetQuery(text)) {
+          return { rows: [] as Row[] };
+        }
+
+        if (isHydrationQuery(text)) {
+          hydrationQueries++;
+          return { rows: seedRows as Row[] };
+        }
+
+        if (isReconciliationQuery(text)) {
+          return { rows: [] as Row[] };
+        }
+
+        throw new Error(`Unexpected query: ${text}`);
       },
     },
     writeCandlesFn: async (_queryable, _tableName, candles) => {
@@ -96,13 +120,25 @@ test("retries startup hydration and replays buffered base candles", async () => 
 
   const aggregator = new Candles1h1mAggregator({
     queryable: {
-      query: async <Row = unknown>(_text: string, _values?: unknown[]) => {
-        hydrationQueries++;
-        if (hydrationQueries === 1) {
-          throw new Error("temporary startup hydration failure");
+      query: async <Row = unknown>(text: string, _values?: unknown[]) => {
+        if (isLatestTargetQuery(text)) {
+          return { rows: [] as Row[] };
         }
 
-        return { rows: seedRows as Row[] };
+        if (isHydrationQuery(text)) {
+          hydrationQueries++;
+          if (hydrationQueries === 1) {
+            throw new Error("temporary startup hydration failure");
+          }
+
+          return { rows: seedRows as Row[] };
+        }
+
+        if (isReconciliationQuery(text)) {
+          return { rows: [] as Row[] };
+        }
+
+        throw new Error(`Unexpected query: ${text}`);
       },
     },
     writeCandlesFn: async (_queryable, _tableName, candles) => {
@@ -115,6 +151,45 @@ test("retries startup hydration and replays buffered base candles", async () => 
 
   await aggregator.flushCompleted();
   assert.equal(hydrationQueries, 2);
+  assert.deepEqual(writtenTimes, [minuteIso(60)]);
+  assert.equal(aggregator.getCandlesWritten(), 1);
+});
+
+test("reconciles missing hourly rows from canonical 1m source on startup", async () => {
+  const hydrationRows = Array.from({ length: 60 }, (_, i) => makeStoredRow(i + 1));
+  const reconciliationRows = Array.from({ length: 61 }, (_, i) => ({
+    ...makeStoredRow(i),
+    latest_target_time: minuteIso(59),
+  }));
+  const writtenTimes: string[] = [];
+
+  const aggregator = new Candles1h1mAggregator({
+    queryable: {
+      query: async <Row = unknown>(text: string, _values?: unknown[]) => {
+        if (isLatestTargetQuery(text)) {
+          return {
+            rows: [{ ticker: "ES", latest_target_time: minuteIso(59) }] as Row[],
+          };
+        }
+
+        if (isHydrationQuery(text)) {
+          return { rows: hydrationRows as Row[] };
+        }
+
+        if (isReconciliationQuery(text)) {
+          return { rows: reconciliationRows as Row[] };
+        }
+
+        throw new Error(`Unexpected query: ${text}`);
+      },
+    },
+    writeCandlesFn: async (_queryable, _tableName, candles) => {
+      writtenTimes.push(...candles.map((candle) => candle.time));
+    },
+  });
+
+  await aggregator.initialize();
+
   assert.deepEqual(writtenTimes, [minuteIso(60)]);
   assert.equal(aggregator.getCandlesWritten(), 1);
 });

--- a/apps/market-write-node/src/stream/candles-1h-1m-aggregator.ts
+++ b/apps/market-write-node/src/stream/candles-1h-1m-aggregator.ts
@@ -8,6 +8,8 @@ const HYDRATION_WINDOW_ROWS = 60;
 const WINDOW_MINUTES = 60;
 const WRITE_BATCH_SIZE = 500;
 const HYDRATION_RETRY_LOG_INTERVAL_MS = 30_000;
+const RECONCILIATION_PAGE_SIZE = 5_000;
+const RECONCILIATION_FLUSH_THRESHOLD = 10_000;
 
 const SOURCE_COLUMNS = `
   time,
@@ -85,11 +87,11 @@ const HYDRATION_QUERY = `
 `;
 
 const LATEST_TARGET_TIMES_QUERY = `
-  SELECT
+  SELECT DISTINCT ON (ticker)
     ticker,
-    MAX(time) AS latest_target_time
+    time AS latest_target_time
   FROM ${TARGET_TABLE}
-  GROUP BY ticker
+  ORDER BY ticker ASC, time DESC
 `;
 
 interface QueryResultLike<Row> {
@@ -107,6 +109,16 @@ interface LatestTargetRow {
 
 interface ReconciliationSourceRow extends StoredCandleRow {
   latest_target_time: Date | string;
+}
+
+interface ReconciliationCursor {
+  ticker: string;
+  time: string;
+}
+
+interface ReconciliationResult {
+  seeded: number;
+  replayed: number;
 }
 
 interface Candles1h1mAggregatorOptions {
@@ -224,42 +236,24 @@ export class Candles1h1mAggregator {
   private async hydrateFromDatabase(): Promise<boolean> {
     try {
       const latestTargetTimes = await this.loadLatestTargetTimes();
-      const [recentSourceRows, reconciliationRows] = await Promise.all([
-        this.queryable.query<StoredCandleRow>(HYDRATION_QUERY, [HYDRATION_WINDOW_ROWS]),
-        this.loadReconciliationRows(latestTargetTimes),
-      ]);
+      const recentSourceRows = await this.queryable.query<StoredCandleRow>(HYDRATION_QUERY, [HYDRATION_WINDOW_ROWS]);
 
       const latestTargetTimeByTicker = new Map(latestTargetTimes.map((row) => [row.ticker, new Date(row.latest_target_time).getTime()]));
       const recentSeedCandles = recentSourceRows.rows
         .filter((row) => !latestTargetTimeByTicker.has(row.ticker))
         .map((row) => candleForDbFromStoredRow(row, { requireCompleteCvd: true }));
-
-      const reconciliationSeedCandles: CandleForDb[] = [];
-      const reconciliationReplayCandles: CandleForDb[] = [];
-      for (const row of reconciliationRows) {
-        const candle = candleForDbFromStoredRow(row, { requireCompleteCvd: true });
-        const latestTargetTimeMs = new Date(row.latest_target_time).getTime();
-
-        if (new Date(candle.time).getTime() <= latestTargetTimeMs) {
-          reconciliationSeedCandles.push(candle);
-          continue;
-        }
-
-        reconciliationReplayCandles.push(candle);
-      }
-
-      const seedCandles = [...recentSeedCandles, ...reconciliationSeedCandles];
+      const reconciliation = await this.reconcileFromSource(latestTargetTimes);
+      const seedCandles = [...recentSeedCandles];
       this.rollingWindow.seedCandles(seedCandles);
-      const replayedFromSource = this.rollingWindow.addCandles(reconciliationReplayCandles);
-      this.initialized = true;
 
-      if (seedCandles.length > 0) {
-        console.log(`📚 Hydrated ${seedCandles.length} canonical 1m row(s) into ${TARGET_TABLE}`);
+      const totalSeeded = seedCandles.length + reconciliation.seeded;
+      if (totalSeeded > 0) {
+        console.log(`📚 Hydrated ${totalSeeded} canonical 1m row(s) into ${TARGET_TABLE}`);
       } else {
         console.log(`📚 No canonical 1m rows available yet to hydrate ${TARGET_TABLE}`);
       }
-      if (replayedFromSource > 0) {
-        console.log(`🔁 Replayed ${replayedFromSource} canonical 1m row(s) newer than ${TARGET_TABLE}`);
+      if (reconciliation.replayed > 0) {
+        console.log(`🔁 Replayed ${reconciliation.replayed} canonical 1m row(s) newer than ${TARGET_TABLE}`);
       }
 
       const replayed = this.replayBufferedBaseCandles();
@@ -267,6 +261,7 @@ export class Candles1h1mAggregator {
         console.log(`📥 Replayed ${replayed} buffered canonical 1m row(s) into ${TARGET_TABLE}`);
       }
 
+      this.initialized = true;
       await this.flushPendingCandles();
 
       return true;
@@ -291,17 +286,69 @@ export class Candles1h1mAggregator {
     return result.rows;
   }
 
-  private async loadReconciliationRows(latestTargetTimes: LatestTargetRow[]): Promise<ReconciliationSourceRow[]> {
+  private async reconcileFromSource(latestTargetTimes: LatestTargetRow[]): Promise<ReconciliationResult> {
     if (latestTargetTimes.length === 0) {
-      return [];
+      return { seeded: 0, replayed: 0 };
     }
 
-    const values: string[] = [];
+    let cursor: ReconciliationCursor | null = null;
+    let seeded = 0;
+    let replayed = 0;
+
+    while (true) {
+      const rows = await this.loadReconciliationRows(latestTargetTimes, cursor);
+      if (rows.length === 0) {
+        break;
+      }
+
+      const reconciliationSeedCandles: CandleForDb[] = [];
+      const reconciliationReplayCandles: CandleForDb[] = [];
+      for (const row of rows) {
+        const candle = candleForDbFromStoredRow(row, { requireCompleteCvd: true });
+        const latestTargetTimeMs = new Date(row.latest_target_time).getTime();
+
+        if (new Date(candle.time).getTime() <= latestTargetTimeMs) {
+          reconciliationSeedCandles.push(candle);
+        } else {
+          reconciliationReplayCandles.push(candle);
+        }
+      }
+
+      if (reconciliationSeedCandles.length > 0) {
+        seeded += reconciliationSeedCandles.length;
+        this.rollingWindow.seedCandles(reconciliationSeedCandles);
+      }
+      if (reconciliationReplayCandles.length > 0) {
+        replayed += this.rollingWindow.addCandles(reconciliationReplayCandles);
+      }
+      if (this.rollingWindow.getStats().pendingCandles >= RECONCILIATION_FLUSH_THRESHOLD) {
+        await this.flushPendingCandles();
+      }
+
+      const lastRow = rows[rows.length - 1];
+      cursor = {
+        ticker: lastRow.ticker,
+        time: lastRow.time instanceof Date ? lastRow.time.toISOString() : new Date(lastRow.time).toISOString(),
+      };
+    }
+
+    return { seeded, replayed };
+  }
+
+  private async loadReconciliationRows(
+    latestTargetTimes: LatestTargetRow[],
+    cursor: ReconciliationCursor | null,
+  ): Promise<ReconciliationSourceRow[]> {
+    const values: unknown[] = [];
     const placeholders = latestTargetTimes.map((row, index) => {
       const offset = index * 2;
       values.push(row.ticker, row.latest_target_time instanceof Date ? row.latest_target_time.toISOString() : row.latest_target_time);
       return `($${offset + 1}, $${offset + 2}::timestamptz)`;
     });
+    const cursorTickerIndex = values.length + 1;
+    const cursorTimeIndex = values.length + 2;
+    const limitIndex = values.length + 3;
+    values.push(cursor?.ticker ?? "", cursor?.time ?? "1970-01-01T00:00:00.000Z", String(RECONCILIATION_PAGE_SIZE));
 
     const query = `
       WITH latest_target(ticker, latest_target_time) AS (
@@ -315,7 +362,12 @@ export class Candles1h1mAggregator {
         ON latest_target.ticker = ${SOURCE_TABLE}.ticker
       WHERE time = date_trunc('minute', time)
         AND time >= latest_target.latest_target_time - INTERVAL '${WINDOW_MINUTES - 1} minutes'
+        AND (
+          $${cursorTickerIndex} = ''
+          OR (${SOURCE_TABLE}.ticker, ${SOURCE_TABLE}.time) > ($${cursorTickerIndex}, $${cursorTimeIndex}::timestamptz)
+        )
       ORDER BY ${SOURCE_TABLE}.ticker ASC, ${SOURCE_TABLE}.time ASC
+      LIMIT $${limitIndex}::int
     `;
 
     const result = await this.queryable.query<ReconciliationSourceRow>(query, values);

--- a/apps/market-write-node/src/stream/candles-1h-1m-aggregator.ts
+++ b/apps/market-write-node/src/stream/candles-1h-1m-aggregator.ts
@@ -9,71 +9,87 @@ const WINDOW_MINUTES = 60;
 const WRITE_BATCH_SIZE = 500;
 const HYDRATION_RETRY_LOG_INTERVAL_MS = 30_000;
 
+const SOURCE_COLUMNS = `
+  time,
+  ticker,
+  symbol,
+  open,
+  high,
+  low,
+  close,
+  volume,
+  ask_volume,
+  bid_volume,
+  cvd_open,
+  cvd_high,
+  cvd_low,
+  cvd_close,
+  trades,
+  max_trade_size,
+  big_trades,
+  big_volume,
+  vd,
+  vd_ratio,
+  book_imbalance,
+  price_pct,
+  divergence,
+  sum_bid_depth,
+  sum_ask_depth,
+  sum_price_volume,
+  unknown_volume
+`;
+
+const SOURCE_COLUMNS_FROM_SOURCE_TABLE = `
+  ${SOURCE_TABLE}.time,
+  ${SOURCE_TABLE}.ticker,
+  ${SOURCE_TABLE}.symbol,
+  ${SOURCE_TABLE}.open,
+  ${SOURCE_TABLE}.high,
+  ${SOURCE_TABLE}.low,
+  ${SOURCE_TABLE}.close,
+  ${SOURCE_TABLE}.volume,
+  ${SOURCE_TABLE}.ask_volume,
+  ${SOURCE_TABLE}.bid_volume,
+  ${SOURCE_TABLE}.cvd_open,
+  ${SOURCE_TABLE}.cvd_high,
+  ${SOURCE_TABLE}.cvd_low,
+  ${SOURCE_TABLE}.cvd_close,
+  ${SOURCE_TABLE}.trades,
+  ${SOURCE_TABLE}.max_trade_size,
+  ${SOURCE_TABLE}.big_trades,
+  ${SOURCE_TABLE}.big_volume,
+  ${SOURCE_TABLE}.vd,
+  ${SOURCE_TABLE}.vd_ratio,
+  ${SOURCE_TABLE}.book_imbalance,
+  ${SOURCE_TABLE}.price_pct,
+  ${SOURCE_TABLE}.divergence,
+  ${SOURCE_TABLE}.sum_bid_depth,
+  ${SOURCE_TABLE}.sum_ask_depth,
+  ${SOURCE_TABLE}.sum_price_volume,
+  ${SOURCE_TABLE}.unknown_volume
+`;
+
 const HYDRATION_QUERY = `
   WITH ranked AS (
     SELECT
-      time,
-      ticker,
-      symbol,
-      open,
-      high,
-      low,
-      close,
-      volume,
-      ask_volume,
-      bid_volume,
-      cvd_open,
-      cvd_high,
-      cvd_low,
-      cvd_close,
-      trades,
-      max_trade_size,
-      big_trades,
-      big_volume,
-      vd,
-      vd_ratio,
-      book_imbalance,
-      price_pct,
-      divergence,
-      sum_bid_depth,
-      sum_ask_depth,
-      sum_price_volume,
-      unknown_volume,
+      ${SOURCE_COLUMNS},
       ROW_NUMBER() OVER (PARTITION BY ticker ORDER BY time DESC) AS rn
     FROM ${SOURCE_TABLE}
     WHERE time = date_trunc('minute', time)
   )
   SELECT
-    time,
-    ticker,
-    symbol,
-    open,
-    high,
-    low,
-    close,
-    volume,
-    ask_volume,
-    bid_volume,
-    cvd_open,
-    cvd_high,
-    cvd_low,
-    cvd_close,
-    trades,
-    max_trade_size,
-    big_trades,
-    big_volume,
-    vd,
-    vd_ratio,
-    book_imbalance,
-    price_pct,
-    divergence,
-    sum_bid_depth,
-    sum_ask_depth,
-    sum_price_volume,
-    unknown_volume
+    ${SOURCE_COLUMNS}
   FROM ranked
   WHERE rn <= $1
   ORDER BY ticker ASC, time ASC
+`;
+
+const LATEST_TARGET_TIMES_QUERY = `
+  SELECT
+    ticker,
+    MAX(time) AS latest_target_time
+  FROM ${TARGET_TABLE}
+  GROUP BY ticker
 `;
 
 interface QueryResultLike<Row> {
@@ -82,6 +98,15 @@ interface QueryResultLike<Row> {
 
 interface Queryable {
   query: <Row = unknown>(text: string, values?: unknown[]) => Promise<QueryResultLike<Row>>;
+}
+
+interface LatestTargetRow {
+  ticker: string;
+  latest_target_time: Date | string;
+}
+
+interface ReconciliationSourceRow extends StoredCandleRow {
+  latest_target_time: Date | string;
 }
 
 interface Candles1h1mAggregatorOptions {
@@ -134,6 +159,18 @@ export class Candles1h1mAggregator {
       return;
     }
 
+    await this.flushPendingCandles();
+  }
+
+  async flushAll(): Promise<void> {
+    await this.flushCompleted();
+  }
+
+  getCandlesWritten(): number {
+    return this.candlesWritten;
+  }
+
+  private async flushPendingCandles(): Promise<void> {
     const pendingCandles = this.rollingWindow.drainPendingCandles();
     if (pendingCandles.length === 0) {
       return;
@@ -169,14 +206,6 @@ export class Candles1h1mAggregator {
     }
   }
 
-  async flushAll(): Promise<void> {
-    await this.flushCompleted();
-  }
-
-  getCandlesWritten(): number {
-    return this.candlesWritten;
-  }
-
   private async ensureInitialized(): Promise<boolean> {
     if (this.initialized) {
       return true;
@@ -194,9 +223,34 @@ export class Candles1h1mAggregator {
 
   private async hydrateFromDatabase(): Promise<boolean> {
     try {
-      const result = await this.queryable.query<StoredCandleRow>(HYDRATION_QUERY, [HYDRATION_WINDOW_ROWS]);
-      const seedCandles = result.rows.map(candleForDbFromStoredRow);
+      const latestTargetTimes = await this.loadLatestTargetTimes();
+      const [recentSourceRows, reconciliationRows] = await Promise.all([
+        this.queryable.query<StoredCandleRow>(HYDRATION_QUERY, [HYDRATION_WINDOW_ROWS]),
+        this.loadReconciliationRows(latestTargetTimes),
+      ]);
+
+      const latestTargetTimeByTicker = new Map(latestTargetTimes.map((row) => [row.ticker, new Date(row.latest_target_time).getTime()]));
+      const recentSeedCandles = recentSourceRows.rows
+        .filter((row) => !latestTargetTimeByTicker.has(row.ticker))
+        .map((row) => candleForDbFromStoredRow(row, { requireCompleteCvd: true }));
+
+      const reconciliationSeedCandles: CandleForDb[] = [];
+      const reconciliationReplayCandles: CandleForDb[] = [];
+      for (const row of reconciliationRows) {
+        const candle = candleForDbFromStoredRow(row, { requireCompleteCvd: true });
+        const latestTargetTimeMs = new Date(row.latest_target_time).getTime();
+
+        if (new Date(candle.time).getTime() <= latestTargetTimeMs) {
+          reconciliationSeedCandles.push(candle);
+          continue;
+        }
+
+        reconciliationReplayCandles.push(candle);
+      }
+
+      const seedCandles = [...recentSeedCandles, ...reconciliationSeedCandles];
       this.rollingWindow.seedCandles(seedCandles);
+      const replayedFromSource = this.rollingWindow.addCandles(reconciliationReplayCandles);
       this.initialized = true;
 
       if (seedCandles.length > 0) {
@@ -204,11 +258,16 @@ export class Candles1h1mAggregator {
       } else {
         console.log(`📚 No canonical 1m rows available yet to hydrate ${TARGET_TABLE}`);
       }
+      if (replayedFromSource > 0) {
+        console.log(`🔁 Replayed ${replayedFromSource} canonical 1m row(s) newer than ${TARGET_TABLE}`);
+      }
 
       const replayed = this.replayBufferedBaseCandles();
       if (replayed > 0) {
         console.log(`📥 Replayed ${replayed} buffered canonical 1m row(s) into ${TARGET_TABLE}`);
       }
+
+      await this.flushPendingCandles();
 
       return true;
     } catch (error) {
@@ -225,6 +284,42 @@ export class Candles1h1mAggregator {
     const buffered = this.bufferedBaseCandles;
     this.bufferedBaseCandles = [];
     return this.rollingWindow.addCandles(buffered);
+  }
+
+  private async loadLatestTargetTimes(): Promise<LatestTargetRow[]> {
+    const result = await this.queryable.query<LatestTargetRow>(LATEST_TARGET_TIMES_QUERY);
+    return result.rows;
+  }
+
+  private async loadReconciliationRows(latestTargetTimes: LatestTargetRow[]): Promise<ReconciliationSourceRow[]> {
+    if (latestTargetTimes.length === 0) {
+      return [];
+    }
+
+    const values: string[] = [];
+    const placeholders = latestTargetTimes.map((row, index) => {
+      const offset = index * 2;
+      values.push(row.ticker, row.latest_target_time instanceof Date ? row.latest_target_time.toISOString() : row.latest_target_time);
+      return `($${offset + 1}, $${offset + 2}::timestamptz)`;
+    });
+
+    const query = `
+      WITH latest_target(ticker, latest_target_time) AS (
+        VALUES ${placeholders.join(", ")}
+      )
+      SELECT
+        ${SOURCE_COLUMNS_FROM_SOURCE_TABLE},
+        latest_target.latest_target_time
+      FROM ${SOURCE_TABLE}
+      JOIN latest_target
+        ON latest_target.ticker = ${SOURCE_TABLE}.ticker
+      WHERE time = date_trunc('minute', time)
+        AND time >= latest_target.latest_target_time - INTERVAL '${WINDOW_MINUTES - 1} minutes'
+      ORDER BY ${SOURCE_TABLE}.ticker ASC, ${SOURCE_TABLE}.time ASC
+    `;
+
+    const result = await this.queryable.query<ReconciliationSourceRow>(query, values);
+    return result.rows;
   }
 
   private maybeLogHydrationBlocked(): void {

--- a/apps/market-write-node/src/stream/tbbo-1m-aggregator.test.ts
+++ b/apps/market-write-node/src/stream/tbbo-1m-aggregator.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+process.env.TIMESCALE_URL ??= "postgres://test:test@localhost:5432/test";
+
+const { Tbbo1mAggregator } = await import("./tbbo-1m-aggregator.js");
+
+test("flushCompleted retries queued hourly writes during idle periods", async () => {
+  let flushCompletedCalls = 0;
+
+  const aggregator = new Tbbo1mAggregator({
+    queryable: {
+      query: async <Row = unknown>() => ({ rows: [] as Row[] }),
+    },
+    writeCandlesFn: async () => {},
+    hourlyAggregator: {
+      initialize: async () => {},
+      addBaseCandles: () => 0,
+      flushCompleted: async () => {
+        flushCompletedCalls++;
+      },
+      flushAll: async () => {},
+    },
+  });
+
+  await aggregator.flushCompleted();
+
+  assert.equal(flushCompletedCalls, 1);
+});

--- a/apps/market-write-node/src/stream/tbbo-1m-aggregator.ts
+++ b/apps/market-write-node/src/stream/tbbo-1m-aggregator.ts
@@ -27,9 +27,32 @@ const WRITE_BATCH_SIZE = 500;
 const STATUS_LOG_INTERVAL_MS = 30_000;
 const WINDOW_SECONDS = 60;
 
+interface QueryResultLike<Row> {
+  rows: Row[];
+}
+
+interface Queryable {
+  query: <Row = unknown>(text: string, values?: unknown[]) => Promise<QueryResultLike<Row>>;
+}
+
+interface HourlyAggregatorLike {
+  initialize(): Promise<void>;
+  addBaseCandles(candles: CandleForDb[]): number;
+  flushCompleted(): Promise<void>;
+  flushAll(): Promise<void>;
+}
+
+interface Tbbo1mAggregatorOptions {
+  queryable?: Queryable;
+  writeCandlesFn?: typeof writeCandles;
+  hourlyAggregator?: HourlyAggregatorLike;
+}
+
 export class Tbbo1mAggregator {
+  private readonly queryable: Queryable;
+  private readonly writeCandlesFn: typeof writeCandles;
   private readonly rollingWindow = new RollingWindow1m();
-  private readonly hourlyAggregator = new Candles1h1mAggregator();
+  private readonly hourlyAggregator: HourlyAggregatorLike;
   private initialized = false;
   private recordsProcessed = 0;
   private candlesWritten = 0;
@@ -39,7 +62,10 @@ export class Tbbo1mAggregator {
     unknownSideTrades: 0,
   };
 
-  constructor() {
+  constructor(options: Tbbo1mAggregatorOptions = {}) {
+    this.queryable = options.queryable ?? pool;
+    this.writeCandlesFn = options.writeCandlesFn ?? writeCandles;
+    this.hourlyAggregator = options.hourlyAggregator ?? new Candles1h1mAggregator();
     console.log("📊 TBBO 1m aggregator created");
   }
 
@@ -50,7 +76,10 @@ export class Tbbo1mAggregator {
     }
 
     try {
-      const result = await pool.query(`
+      const result = await this.queryable.query<{
+        ticker: string;
+        cvd: number | string | null;
+      }>(`
         SELECT DISTINCT ON (ticker) ticker, cvd_close AS cvd
         FROM ${TARGET_TABLE}
         WHERE cvd_close IS NOT NULL
@@ -139,6 +168,7 @@ export class Tbbo1mAggregator {
   async flushCompleted(): Promise<void> {
     this.rollingWindow.finalizeStaleSeconds();
     await this.flushPendingCandles("✅ Flushed", "⚠️ Dropped");
+    await this.hourlyAggregator.flushCompleted();
   }
 
   async flushAll(): Promise<void> {
@@ -221,7 +251,7 @@ export class Tbbo1mAggregator {
     }
 
     try {
-      await writeCandles(pool, TARGET_TABLE, batch);
+      await this.writeCandlesFn(this.queryable, TARGET_TABLE, batch);
       this.candlesWritten += batch.length;
       this.hourlyAggregator.addBaseCandles(batch);
       await this.hourlyAggregator.flushCompleted();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- reconcile `candles_1h_1m` from canonical minute-boundary `candles_1m_1s` rows during startup and flush any recovered hourly rows immediately
- page long startup catch-up reads and flush recovered hourly rows incrementally so restart reconciliation stays bounded during long downtime
- keep retrying queued hourly writes during idle live flush cycles instead of waiting for new 1m writes
- reject malformed canonical source rows with incomplete CVD OHLC and add regression coverage for reconciliation, idle retry, and CVD validation

## Testing
- `pnpm exec tsx --test src/lib/trade/canonical-candle.test.ts src/lib/trade/market-session.test.ts src/lib/trade/rolling-session-continuity.test.ts src/stream/candles-1h-1m-aggregator.test.ts src/stream/tbbo-1m-aggregator.test.ts`
- `pnpm --filter market-write-node build`
- `pnpm build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-408c6fc7-f663-4afe-a276-8e11f2a5ef3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-408c6fc7-f663-4afe-a276-8e11f2a5ef3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

