### PR TITLE
Cache Android tooling, stabilize workspace builds, and fix DB contract checks

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -4,11 +4,20 @@
   "start": "pnpm run cloud:start",
   "persistedDirectories": [
     "/workspace/.pnpm-store",
-    "/workspace/.turbo"
+    "/workspace/.turbo",
+    "/workspace/.android-sdk",
+    "/workspace/.android-user-home",
+    "/workspace/.gradle",
+    "/workspace/apps-marketing/notes-android/.gradle"
   ],
   "env": {
+    "ANDROID_HOME": "/workspace/.android-sdk",
+    "ANDROID_SDK_ROOT": "/workspace/.android-sdk",
+    "ANDROID_USER_HOME": "/workspace/.android-user-home",
     "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0",
+    "GRADLE_USER_HOME": "/workspace/.gradle",
     "HUSKY": "0",
+    "JAVA_HOME": "/usr/lib/jvm/java-21-openjdk-amd64",
     "PNPM_HOME": "/home/ubuntu/.local/share/pnpm",
     "PNPM_STORE_DIR": "/workspace/.pnpm-store",
     "TURBO_TELEMETRY_DISABLED": "1"

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -14,6 +14,7 @@
     "ANDROID_HOME": "/workspace/.android-sdk",
     "ANDROID_SDK_ROOT": "/workspace/.android-sdk",
     "ANDROID_USER_HOME": "/workspace/.android-user-home",
+    "CI": "true",
     "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0",
     "GRADLE_USER_HOME": "/workspace/.gradle",
     "HUSKY": "0",

--- a/.github/workflows/db-contracts.yml
+++ b/.github/workflows/db-contracts.yml
@@ -61,9 +61,12 @@ jobs:
           sudo apt-get install -y postgresql-common ca-certificates
           sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
           sudo apt-get install -y postgresql-client-17
+          echo "/usr/lib/postgresql/17/bin" >> "$GITHUB_PATH"
 
       - name: Show PostgreSQL versions
         run: |
+          which psql
+          which pg_dump
           pg_dump --version
           psql --version
           psql "$TRADING_DB_URL" -Atqc "SELECT version()"
@@ -111,9 +114,12 @@ jobs:
           sudo apt-get install -y postgresql-common ca-certificates
           sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
           sudo apt-get install -y postgresql-client-17
+          echo "/usr/lib/postgresql/17/bin" >> "$GITHUB_PATH"
 
       - name: Show PostgreSQL versions
         run: |
+          which psql
+          which pg_dump
           pg_dump --version
           psql --version
           psql "$TIMESCALE_DB_URL" -Atqc "SELECT version()"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ coverage
 # Tools
 .turbo
 .pnpm-store
+.android-sdk
+.android-user-home
+.gradle
 .vercel
 ._vscode
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,11 @@ In `lib/*` packages:
 
 - Always use `pnpm` (never `npm`)
 - Use `pnpm --filter <app> <command>` or `cd apps/<app> && pnpm run <command>`
+- Never add `pnpm install` / `pnpm i` inside package-level `build`, `dev`, `test`, or `start` scripts. Install dependencies from the workspace root only.
+- For focused work on one app or package, install from the root with a filter that includes that target plus its workspace dependencies, for example:
+  - `pnpm run deps:install -- notes-next...`
+  - `pnpm run deps:install -- @lib/config...`
+- Use a full root install (`pnpm run deps:install`) when running repo-wide commands such as `pnpm build`, when touching multiple apps, or when changing shared workspace dependencies.
 - If request is ambiguous or contradictory, ask for clarification
 
 If DB schema changed:

--- a/apps-marketing/notes-android/scripts/build-android.sh
+++ b/apps-marketing/notes-android/scripts/build-android.sh
@@ -2,96 +2,14 @@
 
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$ROOT_DIR/.android-sdk}}"
+APP_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$APP_ROOT/../.." && pwd)"
+SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$REPO_ROOT/.android-sdk}}"
+
 export ANDROID_SDK_ROOT="$SDK_ROOT"
 export ANDROID_HOME="$SDK_ROOT"
+export ANDROID_USER_HOME="${ANDROID_USER_HOME:-$REPO_ROOT/.android-user-home}"
 
-CMDLINE_TOOLS_DIR="$SDK_ROOT/cmdline-tools/latest"
-SDKMANAGER_BIN="$CMDLINE_TOOLS_DIR/bin/sdkmanager"
+bash "$REPO_ROOT/scripts/install-android-sdk.sh"
 
-ensure_cmdline_tools() {
-  if [[ -x "$SDKMANAGER_BIN" ]]; then
-    return
-  fi
-
-  echo "Bootstrapping Android command-line tools into $SDK_ROOT"
-  mkdir -p "$SDK_ROOT/cmdline-tools"
-
-  local tmp_dir
-  tmp_dir="$(mktemp -d)"
-
-  python3 - "$tmp_dir/url.txt" <<'PY'
-import sys
-import urllib.request
-import xml.etree.ElementTree as ET
-
-output_path = sys.argv[1]
-repository_url = "https://dl.google.com/android/repository/repository2-1.xml"
-document = urllib.request.urlopen(repository_url, timeout=30).read()
-root = ET.fromstring(document)
-
-archive_url = None
-best_version = None
-
-for remote_package in root.iter("remotePackage"):
-    package_path = remote_package.attrib.get("path", "")
-    if not package_path.startswith("cmdline-tools;"):
-        continue
-
-    try:
-        version = tuple(int(part) for part in package_path.split(";", 1)[1].split("."))
-    except Exception:
-        continue
-
-    archives = remote_package.find("archives")
-    if archives is None:
-        continue
-
-    candidate_url = None
-    for archive in archives.findall("archive"):
-        host_os = archive.findtext("host-os")
-        if host_os != "linux":
-            continue
-        complete = archive.find("complete")
-        if complete is None:
-            continue
-        url = complete.findtext("url")
-        if url:
-            candidate_url = f"https://dl.google.com/android/repository/{url}"
-            break
-
-    if candidate_url and (best_version is None or version > best_version):
-        best_version = version
-        archive_url = candidate_url
-
-if not archive_url:
-    raise SystemExit("Failed to locate Android command-line tools download URL.")
-
-with open(output_path, "w", encoding="utf-8") as handle:
-    handle.write(archive_url)
-PY
-
-  local archive_url
-  archive_url="$(<"$tmp_dir/url.txt")"
-
-  curl -L "$archive_url" -o "$tmp_dir/commandlinetools.zip"
-  unzip -q "$tmp_dir/commandlinetools.zip" -d "$tmp_dir/unpacked"
-
-  rm -rf "$CMDLINE_TOOLS_DIR"
-  mv "$tmp_dir/unpacked/cmdline-tools" "$CMDLINE_TOOLS_DIR"
-  rm -rf "$tmp_dir"
-}
-
-install_android_packages() {
-  yes | "$SDKMANAGER_BIN" --sdk_root="$SDK_ROOT" --licenses >/dev/null || true
-  "$SDKMANAGER_BIN" --sdk_root="$SDK_ROOT" \
-    "platform-tools" \
-    "platforms;android-36" \
-    "build-tools;36.0.0"
-}
-
-ensure_cmdline_tools
-install_android_packages
-
-"$ROOT_DIR/gradlew" --no-daemon :app:assembleDebug
+"$APP_ROOT/gradlew" --no-daemon :app:assembleDebug

--- a/apps-trading/log-next/package.json
+++ b/apps-trading/log-next/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --port 3333",
-    "build": "pnpm i && next build",
+    "build": "next build",
     "env:pull": "node ../../scripts/fetch-infisical.mjs --app log-next",
     "analyze": "ANALYZE=true next build",
     "start": "next start",

--- a/apps-trading/tradingview-node/package.json
+++ b/apps-trading/tradingview-node/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "dev": "tsx watch src/index.ts",
-    "build": "pnpm i && tsc --noEmit",
+    "build": "tsc --noEmit",
     "env:pull": "node ../../scripts/fetch-infisical.mjs --app tradingview-node",
     "test": "NODE_ENV=test node --import tsx --import ./src/test/setup.ts --test src/**/*.test.ts"
   },

--- a/apps-trading/view-next/package.json
+++ b/apps-trading/view-next/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --port 3333",
-    "build": "pnpm i && next build",
+    "build": "next build",
     "env:pull": "node ../../scripts/fetch-infisical.mjs --app view-next",
     "analyze": "ANALYZE=true next build",
     "start": "next start",

--- a/apps-trading/write-node/package.json
+++ b/apps-trading/write-node/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "dev": "tsx watch src/index.ts",
-    "build": "pnpm i && tsc --noEmit",
+    "build": "tsc --noEmit",
     "historical:tbbo": "tsx scripts/tbbo-1m-1s.ts",
     "historical:1h1m": "tsx scripts/candles-1h-1m.ts",
     "env:pull": "node ../../scripts/fetch-infisical.mjs --app write-node"

--- a/lib/config/package.json
+++ b/lib/config/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "autoprefixer": "^10.4.20",
     "postcss-preset-mantine": "^1.17.0",
-    "postcss-simple-vars": "^7.0.1"
+    "postcss-simple-vars": "^7.0.1",
+    "tailwindcss": "^4.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",

--- a/lib/db-marketing/scripts/snapshot-schema.sh
+++ b/lib/db-marketing/scripts/snapshot-schema.sh
@@ -10,9 +10,14 @@ if [[ -z "${MARKETING_DB_URL:-}" ]]; then
   exit 1
 fi
 
-bash "${repo_root}/scripts/check-postgres-client-version.sh" MARKETING_DB_URL "@lib/db-marketing"
+eval "$(
+  bash "${repo_root}/scripts/check-postgres-client-version.sh" \
+    MARKETING_DB_URL \
+    "@lib/db-marketing" \
+    --print-env
+)"
 
-pg_dump "$MARKETING_DB_URL" \
+"${CURSOR_POSTGRES_PG_DUMP}" "$MARKETING_DB_URL" \
   --schema-only \
   --schema=public \
   --no-owner \

--- a/lib/db-timescale/scripts/snapshot-schema.sh
+++ b/lib/db-timescale/scripts/snapshot-schema.sh
@@ -10,9 +10,14 @@ if [[ -z "${TIMESCALE_DB_URL:-}" ]]; then
   exit 1
 fi
 
-bash "${repo_root}/scripts/check-postgres-client-version.sh" TIMESCALE_DB_URL "@lib/db-timescale"
+eval "$(
+  bash "${repo_root}/scripts/check-postgres-client-version.sh" \
+    TIMESCALE_DB_URL \
+    "@lib/db-timescale" \
+    --print-env
+)"
 
-pg_dump "$TIMESCALE_DB_URL" \
+"${CURSOR_POSTGRES_PG_DUMP}" "$TIMESCALE_DB_URL" \
   --schema-only \
   --schema=public \
   --no-owner \

--- a/lib/db-trading/scripts/snapshot-schema.sh
+++ b/lib/db-trading/scripts/snapshot-schema.sh
@@ -10,9 +10,14 @@ if [[ -z "${TRADING_DB_URL:-}" ]]; then
   exit 1
 fi
 
-bash "${repo_root}/scripts/check-postgres-client-version.sh" TRADING_DB_URL "@lib/db-trading"
+eval "$(
+  bash "${repo_root}/scripts/check-postgres-client-version.sh" \
+    TRADING_DB_URL \
+    "@lib/db-trading" \
+    --print-env
+)"
 
-pg_dump "$TRADING_DB_URL" \
+"${CURSOR_POSTGRES_PG_DUMP}" "$TRADING_DB_URL" \
   --schema-only \
   --schema=public \
   --no-owner \

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build": "turbo run build",
     "build:write-node": "turbo run build --filter=write-node...",
+    "deps:install": "bash scripts/install-workspace-deps.sh",
     "test": "turbo run test",
     "dev": "turbo run dev",
     "dev:write-node": "pnpm --filter write-node dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -515,6 +515,9 @@ importers:
       postcss-simple-vars:
         specifier: ^7.0.1
         version: 7.0.1(postcss@8.5.8)
+      tailwindcss:
+        specifier: ^4.2.1
+        version: 4.2.1
     devDependencies:
       '@eslint/js':
         specifier: ^9.31.0
@@ -5228,6 +5231,9 @@ packages:
 
   tailwindcss@4.1.13:
     resolution: {integrity: sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==}
+
+  tailwindcss@4.2.1:
+    resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
 
   tapable@2.2.3:
     resolution: {integrity: sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==}
@@ -11414,6 +11420,8 @@ snapshots:
       - yaml
 
   tailwindcss@4.1.13: {}
+
+  tailwindcss@4.2.1: {}
 
   tapable@2.2.3: {}
 

--- a/scripts/check-postgres-client-version.sh
+++ b/scripts/check-postgres-client-version.sh
@@ -1,21 +1,70 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 2 ]]; then
-  echo "Usage: $0 <DATABASE_URL_ENV_VAR> <label>" >&2
+usage() {
+  echo "Usage: $0 <DATABASE_URL_ENV_VAR> <label> [--print-env]" >&2
+}
+
+extract_major() {
+  local version_output="$1"
+  printf '%s\n' "$version_output" \
+    | sed -nE 's/.* ([0-9]+)(\.[0-9]+)?([[:space:]].*)?$/\1/p'
+}
+
+pick_highest_versioned_bin() {
+  local command_name="$1"
+  local candidates=()
+  local latest=""
+
+  shopt -s nullglob
+  candidates=(/usr/lib/postgresql/*/bin/"${command_name}")
+  shopt -u nullglob
+
+  if [[ ${#candidates[@]} -eq 0 ]]; then
+    return 1
+  fi
+
+  latest="$(
+    printf '%s\n' "${candidates[@]}" \
+      | sort -V \
+      | sed -n '$p'
+  )"
+
+  if [[ -z "$latest" ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "$latest"
+}
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  usage
   exit 1
 fi
 
 database_url_env="$1"
 label="$2"
-database_url="${!database_url_env:-}"
+print_env="${3:-}"
 
+if [[ -n "$print_env" && "$print_env" != "--print-env" ]]; then
+  usage
+  exit 1
+fi
+
+database_url="${!database_url_env:-}"
 if [[ -z "$database_url" ]]; then
   echo "${database_url_env} is required" >&2
   exit 1
 fi
 
-if ! command -v psql >/dev/null 2>&1 || ! command -v pg_dump >/dev/null 2>&1; then
+probe_psql=""
+if ! probe_psql="$(pick_highest_versioned_bin psql)"; then
+  if command -v psql >/dev/null 2>&1; then
+    probe_psql="$(command -v psql)"
+  fi
+fi
+
+if [[ -z "$probe_psql" ]]; then
   cat >&2 <<'EOF'
 PostgreSQL client tools are required to verify DB contracts.
 
@@ -31,32 +80,61 @@ Examples:
   Homebrew:
     brew install postgresql@17
 
-After installation, ensure `psql --version` and `pg_dump --version` report the
-same PostgreSQL major version as the DB server.
+If Debian/Ubuntu installs multiple PostgreSQL client majors, the versioned
+binaries under `/usr/lib/postgresql/<major>/bin/` avoid wrapper mismatches.
 EOF
   exit 1
 fi
 
 server_major="$(
-  psql "$database_url" -Atqc "SELECT current_setting('server_version_num')::int / 10000"
+  "$probe_psql" "$database_url" -Atqc "SELECT current_setting('server_version_num')::int / 10000"
 )"
-pg_dump_version="$(pg_dump --version)"
-client_major="$(
-  printf '%s\n' "$pg_dump_version" \
-    | sed -E 's/.* ([0-9]+)(\.[0-9]+)?([[:space:]].*)?$/\1/'
-)"
-
-if [[ -z "$server_major" || -z "$client_major" ]]; then
-  echo "Unable to determine PostgreSQL client/server major versions for ${label}" >&2
+if [[ -z "$server_major" ]]; then
+  echo "Unable to determine PostgreSQL server major version for ${label}" >&2
   exit 1
 fi
 
-if [[ "$client_major" != "$server_major" ]]; then
+psql_bin="/usr/lib/postgresql/${server_major}/bin/psql"
+pg_dump_bin="/usr/lib/postgresql/${server_major}/bin/pg_dump"
+
+if [[ ! -x "$psql_bin" ]]; then
+  if command -v psql >/dev/null 2>&1; then
+    psql_bin="$(command -v psql)"
+  else
+    psql_bin="$probe_psql"
+  fi
+fi
+
+if [[ ! -x "$pg_dump_bin" ]]; then
+  if command -v pg_dump >/dev/null 2>&1; then
+    pg_dump_bin="$(command -v pg_dump)"
+  else
+    pg_dump_bin=""
+  fi
+fi
+
+if [[ -z "$pg_dump_bin" || ! -x "$pg_dump_bin" ]]; then
+  echo "Unable to locate pg_dump for ${label}" >&2
+  exit 1
+fi
+
+psql_version="$("$psql_bin" --version)"
+pg_dump_version="$("$pg_dump_bin" --version)"
+psql_major="$(extract_major "$psql_version")"
+pg_dump_major="$(extract_major "$pg_dump_version")"
+
+if [[ -z "$psql_major" || -z "$pg_dump_major" ]]; then
+  echo "Unable to determine PostgreSQL client major versions for ${label}" >&2
+  exit 1
+fi
+
+if [[ "$psql_major" != "$server_major" || "$pg_dump_major" != "$server_major" ]]; then
   cat >&2 <<EOF
 PostgreSQL client/server major version mismatch for ${label}.
 
   server major: ${server_major}
-  pg_dump: ${pg_dump_version}
+  psql: ${psql_version} (${psql_bin})
+  pg_dump: ${pg_dump_version} (${pg_dump_bin})
 
 Install PostgreSQL client ${server_major} locally so schema snapshots match the
 PostgreSQL ${server_major} service containers used in CI.
@@ -71,9 +149,17 @@ Examples:
     brew install postgresql@${server_major}
 
 After installation, ensure `psql` and `pg_dump` resolve to PostgreSQL
-${server_major} before rerunning this command.
+${server_major}, or invoke the versioned binaries under
+`/usr/lib/postgresql/${server_major}/bin/` directly.
 EOF
   exit 1
 fi
 
-echo "Using ${pg_dump_version} against ${label} server major ${server_major}"
+echo "Using ${psql_version} at ${psql_bin} against ${label} server major ${server_major}" >&2
+echo "Using ${pg_dump_version} at ${pg_dump_bin}" >&2
+
+if [[ "$print_env" == "--print-env" ]]; then
+  printf 'export CURSOR_POSTGRES_SERVER_MAJOR=%q\n' "$server_major"
+  printf 'export CURSOR_POSTGRES_PSQL=%q\n' "$psql_bin"
+  printf 'export CURSOR_POSTGRES_PG_DUMP=%q\n' "$pg_dump_bin"
+fi

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -12,27 +12,14 @@ export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 export GRADLE_USER_HOME="${GRADLE_USER_HOME:-$ROOT_DIR/.gradle}"
 export HUSKY="${HUSKY:-0}"
 export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-21-openjdk-amd64}"
-export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
-STORE_DIR="${PNPM_STORE_DIR:-$ROOT_DIR/.pnpm-store}"
 
 mkdir -p \
-  "$PNPM_HOME" \
-  "$STORE_DIR" \
   "$ROOT_DIR/.turbo" \
   "$ANDROID_SDK_ROOT" \
   "$ANDROID_USER_HOME" \
   "$GRADLE_USER_HOME"
 
-case ":$PATH:" in
-  *":$PNPM_HOME:"*) ;;
-  *) export PATH="$PNPM_HOME:$PATH" ;;
-esac
-
-corepack enable
-corepack prepare pnpm@10.28.1 --activate
-
-pnpm fetch --store-dir "$STORE_DIR"
-pnpm install --frozen-lockfile --prefer-offline --store-dir "$STORE_DIR"
+bash scripts/install-workspace-deps.sh "$@"
 
 bash scripts/install-android-sdk.sh
 

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -4,12 +4,23 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$ROOT_DIR/.android-sdk}"
+export ANDROID_HOME="${ANDROID_HOME:-$ANDROID_SDK_ROOT}"
+export ANDROID_USER_HOME="${ANDROID_USER_HOME:-$ROOT_DIR/.android-user-home}"
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+export GRADLE_USER_HOME="${GRADLE_USER_HOME:-$ROOT_DIR/.gradle}"
 export HUSKY="${HUSKY:-0}"
+export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-21-openjdk-amd64}"
 export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
 STORE_DIR="${PNPM_STORE_DIR:-$ROOT_DIR/.pnpm-store}"
 
-mkdir -p "$PNPM_HOME" "$STORE_DIR" "$ROOT_DIR/.turbo"
+mkdir -p \
+  "$PNPM_HOME" \
+  "$STORE_DIR" \
+  "$ROOT_DIR/.turbo" \
+  "$ANDROID_SDK_ROOT" \
+  "$ANDROID_USER_HOME" \
+  "$GRADLE_USER_HOME"
 
 case ":$PATH:" in
   *":$PNPM_HOME:"*) ;;
@@ -21,3 +32,10 @@ corepack prepare pnpm@10.28.1 --activate
 
 pnpm fetch --store-dir "$STORE_DIR"
 pnpm install --frozen-lockfile --prefer-offline --store-dir "$STORE_DIR"
+
+bash scripts/install-android-sdk.sh
+
+(
+  cd apps-marketing/notes-android
+  ./gradlew --no-daemon :app:help >/dev/null
+)

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -12,12 +12,22 @@ export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 export GRADLE_USER_HOME="${GRADLE_USER_HOME:-$ROOT_DIR/.gradle}"
 export HUSKY="${HUSKY:-0}"
 export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-21-openjdk-amd64}"
+export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
+STORE_DIR="${PNPM_STORE_DIR:-$ROOT_DIR/.pnpm-store}"
+PG17_BINDIR="/usr/lib/postgresql/17/bin"
 
 mkdir -p \
   "$ROOT_DIR/.turbo" \
   "$ANDROID_SDK_ROOT" \
   "$ANDROID_USER_HOME" \
-  "$GRADLE_USER_HOME"
+  "$GRADLE_USER_HOME" \
+  "$PNPM_HOME" \
+  "$STORE_DIR"
+
+case ":$PATH:" in
+  *":$PNPM_HOME:"*) ;;
+  *) export PATH="$PNPM_HOME:$PATH" ;;
+esac
 
 bash scripts/install-workspace-deps.sh "$@"
 
@@ -29,12 +39,22 @@ bash scripts/install-android-sdk.sh
   ./gradlew --no-daemon :app:help >/dev/null
 )
 
+has_pg17_clients() {
+  if [[ -x "${PG17_BINDIR}/psql" && -x "${PG17_BINDIR}/pg_dump" ]]; then
+    return 0
+  fi
+
+  if ! command -v psql >/dev/null 2>&1 || ! command -v pg_dump >/dev/null 2>&1; then
+    return 1
+  fi
+
+  psql --version | grep -qE '\b17(\.|[[:space:]])' \
+    && pg_dump --version | grep -qE '\b17(\.|[[:space:]])'
+}
 
 # Install PostgreSQL 17 client tools (psql, pg_dump) for db:migrate and db:verify
 need_pg17=false
-if ! command -v psql >/dev/null 2>&1 || ! command -v pg_dump >/dev/null 2>&1; then
-  need_pg17=true
-elif ! pg_dump --version | grep -qE '\b17[.[]'; then
+if ! has_pg17_clients; then
   need_pg17=true
 fi
 if [[ "$need_pg17" == "true" ]]; then
@@ -43,7 +63,12 @@ if [[ "$need_pg17" == "true" ]]; then
   sudo apt-get install -y postgresql-common ca-certificates
   sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
   sudo apt-get install -y postgresql-client-17
-  echo "PostgreSQL client tools installed: $(pg_dump --version)"
+fi
+
+if [[ -x "${PG17_BINDIR}/pg_dump" ]]; then
+  echo "PostgreSQL client tools ready: $("${PG17_BINDIR}/pg_dump" --version)"
+elif command -v pg_dump >/dev/null 2>&1; then
+  echo "PostgreSQL client tools ready: $(pg_dump --version)"
 fi
 
 pnpm fetch --store-dir "$STORE_DIR"

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -7,6 +7,7 @@ cd "$ROOT_DIR"
 export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$ROOT_DIR/.android-sdk}"
 export ANDROID_HOME="${ANDROID_HOME:-$ANDROID_SDK_ROOT}"
 export ANDROID_USER_HOME="${ANDROID_USER_HOME:-$ROOT_DIR/.android-user-home}"
+export CI="${CI:-true}"
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 export GRADLE_USER_HOME="${GRADLE_USER_HOME:-$ROOT_DIR/.gradle}"
 export HUSKY="${HUSKY:-0}"

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -48,4 +48,3 @@ fi
 
 pnpm fetch --store-dir "$STORE_DIR"
 pnpm install --frozen-lockfile --prefer-offline --store-dir "$STORE_DIR"
->>>>>>> main

--- a/scripts/cloud-agent-start.sh
+++ b/scripts/cloud-agent-start.sh
@@ -4,6 +4,14 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+pg17_bindir="/usr/lib/postgresql/17/bin"
+if [[ -d "$pg17_bindir" ]]; then
+  case ":$PATH:" in
+    *":$pg17_bindir:"*) ;;
+    *) export PATH="$pg17_bindir:$PATH" ;;
+  esac
+fi
+
 expected_env_files=(
   "apps-trading/log-next/.env"
   "apps-trading/view-next/.env"

--- a/scripts/cloud-agent-start.sh
+++ b/scripts/cloud-agent-start.sh
@@ -33,5 +33,6 @@ fi
 
 echo "Workspace ready."
 echo "Recommended commands:"
+echo "  pnpm run deps:install -- <package>..."
 echo "  pnpm dev:write-node"
 echo "  pnpm build:write-node"

--- a/scripts/install-android-sdk.sh
+++ b/scripts/install-android-sdk.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$ROOT_DIR/.android-sdk}}"
+ANDROID_USER_HOME_DIR="${ANDROID_USER_HOME:-$ROOT_DIR/.android-user-home}"
+
+export ANDROID_SDK_ROOT="$SDK_ROOT"
+export ANDROID_HOME="$SDK_ROOT"
+export ANDROID_USER_HOME="$ANDROID_USER_HOME_DIR"
+
+CMDLINE_TOOLS_DIR="$SDK_ROOT/cmdline-tools/latest"
+SDKMANAGER_BIN="$CMDLINE_TOOLS_DIR/bin/sdkmanager"
+
+has_required_packages() {
+  [[ -x "$SDKMANAGER_BIN" ]] &&
+    [[ -x "$SDK_ROOT/platform-tools/adb" ]] &&
+    [[ -f "$SDK_ROOT/platforms/android-36/android.jar" ]] &&
+    [[ -x "$SDK_ROOT/build-tools/36.0.0/d8" ]]
+}
+
+ensure_cmdline_tools() {
+  if [[ -x "$SDKMANAGER_BIN" ]]; then
+    return
+  fi
+
+  echo "Installing Android command-line tools into $SDK_ROOT"
+  mkdir -p "$SDK_ROOT/cmdline-tools" "$ANDROID_USER_HOME_DIR"
+  touch "$ANDROID_USER_HOME_DIR/repositories.cfg"
+
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' RETURN
+
+  python3 - "$tmp_dir/url.txt" <<'PY'
+import sys
+import urllib.request
+import xml.etree.ElementTree as ET
+
+output_path = sys.argv[1]
+repository_url = "https://dl.google.com/android/repository/repository2-1.xml"
+document = urllib.request.urlopen(repository_url, timeout=30).read()
+root = ET.fromstring(document)
+
+archive_url = None
+best_version = None
+
+for remote_package in root.iter("remotePackage"):
+    package_path = remote_package.attrib.get("path", "")
+    if not package_path.startswith("cmdline-tools;"):
+        continue
+
+    try:
+        version = tuple(int(part) for part in package_path.split(";", 1)[1].split("."))
+    except Exception:
+        continue
+
+    archives = remote_package.find("archives")
+    if archives is None:
+        continue
+
+    candidate_url = None
+    for archive in archives.findall("archive"):
+        host_os = archive.findtext("host-os")
+        if host_os != "linux":
+            continue
+        complete = archive.find("complete")
+        if complete is None:
+            continue
+        url = complete.findtext("url")
+        if url:
+            candidate_url = f"https://dl.google.com/android/repository/{url}"
+            break
+
+    if candidate_url and (best_version is None or version > best_version):
+        best_version = version
+        archive_url = candidate_url
+
+if not archive_url:
+    raise SystemExit("Failed to locate Android command-line tools download URL.")
+
+with open(output_path, "w", encoding="utf-8") as handle:
+    handle.write(archive_url)
+PY
+
+  local archive_url
+  archive_url="$(<"$tmp_dir/url.txt")"
+
+  curl -fsSL "$archive_url" -o "$tmp_dir/commandlinetools.zip"
+  unzip -q "$tmp_dir/commandlinetools.zip" -d "$tmp_dir/unpacked"
+
+  rm -rf "$CMDLINE_TOOLS_DIR"
+  mv "$tmp_dir/unpacked/cmdline-tools" "$CMDLINE_TOOLS_DIR"
+}
+
+install_android_packages() {
+  if has_required_packages; then
+    echo "Android SDK packages already available in $SDK_ROOT"
+    return
+  fi
+
+  mkdir -p "$SDK_ROOT" "$ANDROID_USER_HOME_DIR"
+  touch "$ANDROID_USER_HOME_DIR/repositories.cfg"
+
+  yes | "$SDKMANAGER_BIN" --sdk_root="$SDK_ROOT" --licenses >/dev/null || true
+  "$SDKMANAGER_BIN" --sdk_root="$SDK_ROOT" \
+    "platform-tools" \
+    "platforms;android-36" \
+    "build-tools;36.0.0"
+}
+
+ensure_cmdline_tools
+install_android_packages

--- a/scripts/install-workspace-deps.sh
+++ b/scripts/install-workspace-deps.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+export COREPACK_ENABLE_DOWNLOAD_PROMPT="${COREPACK_ENABLE_DOWNLOAD_PROMPT:-0}"
+export CI="${CI:-true}"
+export HUSKY="${HUSKY:-0}"
+export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
+STORE_DIR="${PNPM_STORE_DIR:-$ROOT_DIR/.pnpm-store}"
+
+mkdir -p "$PNPM_HOME" "$STORE_DIR" "$ROOT_DIR/.turbo"
+
+case ":$PATH:" in
+  *":$PNPM_HOME:"*) ;;
+  *) export PATH="$PNPM_HOME:$PATH" ;;
+esac
+
+corepack enable
+corepack prepare pnpm@10.28.1 --activate
+
+FILTER_ARGS=()
+if (($# > 0)) && [[ "$1" == "--" ]]; then
+  shift
+fi
+
+if (($# > 0)); then
+  for filter in "$@"; do
+    FILTER_ARGS+=(--filter "$filter")
+  done
+  echo "Installing workspace dependencies for filters: $*"
+else
+  echo "Installing workspace dependencies for all packages"
+fi
+
+pnpm fetch --store-dir "$STORE_DIR" "${FILTER_ARGS[@]}"
+pnpm install --frozen-lockfile --prefer-offline --store-dir "$STORE_DIR" "${FILTER_ARGS[@]}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- persist Android SDK, Android user state, and Gradle caches in the Cursor cloud environment
- preinstall Android command-line tools, platform-tools, platforms;android-36, and build-tools;36.0.0 during cloud setup
- share Android SDK provisioning between cloud install and `notes-android`'s build script so the app reuses the cached SDK instead of bootstrapping every build
- mark cloud sessions as CI to avoid interactive `pnpm i` failures in non-TTY package build scripts
- remove package-local `pnpm i` calls from Turbo build scripts so concurrent builds stop mutating workspace `node_modules`
- add `tailwindcss` to `@lib/config` so apps importing shared Tailwind CSS resolve its package-owned dependency correctly
- add a root `pnpm run deps:install` workflow, including filtered installs such as `pnpm run deps:install -- notes-next...`, and document that package scripts must never run installs
- force DB contract verification to use PostgreSQL 17 client binaries in GitHub Actions and DB snapshot scripts so CI never falls back to a mismatched `pg_dump`
- harden cloud agent PostgreSQL 17 detection and PATH setup so `db:migrate` and `db:verify` are more reliable in fresh sessions

## Testing
- `CI=true pnpm install --frozen-lockfile`
- `CI=true pnpm build`
- `CI=true pnpm build`
- GitHub Actions: `DB Contracts` workflow run `23201334214` (`Verify Trading contract` and `Verify Timescale contract` succeeded)
- previously completed on this branch:
  - `pnpm run cloud:install`
  - `pnpm --filter notes-android build`
  - `CI=true pnpm --filter notes-next build`
  - `CI=true pnpm --filter eighthbrain-next build`
  - `pnpm run deps:install -- notes-next...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d6db745-9dfa-4611-ba40-7acfa8b443b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d6db745-9dfa-4611-ba40-7acfa8b443b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

