### PR TITLE
fix: stabilize db contract checks

### DIFF
--- a/.github/workflows/db-contracts.yml
+++ b/.github/workflows/db-contracts.yml
@@ -8,8 +8,8 @@ on:
       - "pnpm-lock.yaml"
       - "lib/db-trading/**"
       - "lib/db-timescale/**"
-      - "apps/view-next/**"
-      - "apps/tradingview-node/**"
+      - "apps-trading/view-next/**"
+      - "apps-trading/tradingview-node/**"
   push:
     branches:
       - main
@@ -19,17 +19,17 @@ on:
       - "pnpm-lock.yaml"
       - "lib/db-trading/**"
       - "lib/db-timescale/**"
-      - "apps/view-next/**"
-      - "apps/tradingview-node/**"
+      - "apps-trading/view-next/**"
+      - "apps-trading/tradingview-node/**"
   workflow_dispatch:
 
 jobs:
-  verify-postgres:
-    name: Verify Postgres contract
+  verify-trading:
+    name: Verify Trading contract
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:17
+        image: postgres:17.9
         env:
           POSTGRES_DB: app_contracts
           POSTGRES_USER: postgres
@@ -55,8 +55,18 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - name: Install PostgreSQL client tools
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Install PostgreSQL 17 client tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-common ca-certificates
+          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+          sudo apt-get install -y postgresql-client-17
+
+      - name: Show PostgreSQL versions
+        run: |
+          pg_dump --version
+          psql --version
+          psql "$TRADING_DB_URL" -Atqc "SELECT version()"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -69,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       timescale:
-        image: timescale/timescaledb:latest-pg17
+        image: timescale/timescaledb:2.25.2-pg17
         env:
           POSTGRES_DB: app_contracts
           POSTGRES_USER: postgres
@@ -95,8 +105,18 @@ jobs:
           node-version: 20
           cache: pnpm
 
-      - name: Install PostgreSQL client tools
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Install PostgreSQL 17 client tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-common ca-certificates
+          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+          sudo apt-get install -y postgresql-client-17
+
+      - name: Show PostgreSQL versions
+        run: |
+          pg_dump --version
+          psql --version
+          psql "$TIMESCALE_DB_URL" -Atqc "SELECT version()"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,9 +51,12 @@ In `lib/*` packages:
 - Use `pnpm --filter <app> <command>` or `cd apps/<app> && pnpm run <command>`
 - If request is ambiguous or contradictory, ask for clarification
 
-If DB schema changed:
+Remote DB operations:
 
-- Instruct the user to run `pnpm --filter @lib/db-marketing db:migrate` to update the database to match the latest table structure. Do not run this yourself.
+- `db:migrate` writes to the target database.
+- `db:verify` is not read-only; it runs `db:migrate` first, then regenerates local contract artifacts.
+- Only run remote `db:migrate` / `db:verify` when the user explicitly requests it.
+- Before running against a deployed DB, confirm the environment variable is present, the host is reachable from the cloud agent, and there are no unexpected pending migrations.
 
 ## Finish task:
 

--- a/docs/db/cloud-agent-handoff.md
+++ b/docs/db/cloud-agent-handoff.md
@@ -1,0 +1,137 @@
+# Cloud Agent DB Handoff
+
+## Branch
+
+- `cursor/db-contract-checks-2d68`
+
+## What was completed
+
+### DB contract workflow and tooling
+
+- Renamed the GitHub Actions check from `Verify Postgres contract` to
+  `Verify Trading contract`.
+- Fixed stale workflow path filters to use `apps-trading/...`.
+- Pinned CI database service versions and installed PostgreSQL 17 client tools
+  in CI.
+- Added a shared PostgreSQL client/server major-version preflight script:
+  `scripts/check-postgres-client-version.sh`.
+- Hardened schema snapshot scripts for:
+  - `@lib/db-trading`
+  - `@lib/db-timescale`
+  - `@lib/db-marketing`
+- Removed `pg_dump` version-banner noise from committed schema snapshots so
+  contract files are deterministic across matching PostgreSQL 17 clients.
+
+### Verify-script correctness
+
+- Fixed all DB package `db:verify` scripts so `git diff --exit-code` checks the
+  correct package-local artifact paths:
+  - `lib/db-trading/scripts/verify-contract.mjs`
+  - `lib/db-timescale/scripts/verify-contract.mjs`
+  - `lib/db-marketing/scripts/verify-contract.mjs`
+
+### Contract artifacts committed
+
+- Committed regenerated DB contract artifacts for trading and timescale.
+- Committed the normalized marketing schema snapshot after applying the same
+  deterministic snapshot rules there.
+
+### Documentation / agent instructions
+
+- Updated:
+  - `AGENTS.md`
+  - `docs/db/management-playbook.md`
+  - `lib/db-trading/AGENTS.md`
+  - `lib/db-timescale/AGENTS.md`
+  - `lib/db-marketing/AGENTS.md`
+  - `lib/db-trading/README.md`
+  - `lib/db-timescale/README.md`
+  - `lib/db-marketing/README.md`
+- Remote `db:migrate` / `db:verify` is now explicitly documented as allowed
+  only when the user asks for it.
+- Docs now explicitly state that `db:verify` is not read-only because it runs
+  `db:migrate` first.
+
+## Remote DB results from this agent
+
+### Succeeded against real deployed databases
+
+- `@lib/db-timescale`
+  - `pnpm --filter @lib/db-timescale db:migrate`
+  - `pnpm --filter @lib/db-timescale db:verify`
+- `@lib/db-marketing`
+  - `pnpm --filter @lib/db-marketing db:migrate`
+  - `pnpm --filter @lib/db-marketing db:verify`
+
+Both remote databases were reachable from this cloud environment and both
+already had all known migrations applied before the commands were run.
+
+### Trading DB status in this specific agent session
+
+- `TRADING_DB_URL` was still injected into this running agent as:
+  - host `postgres.railway.internal`
+- That host is a Railway private-network hostname and was not resolvable from
+  this cloud machine.
+- The user later corrected the Trading DB secret, but this running agent did
+  not receive the updated secret value.
+
+## Why a fresh cloud agent session is needed
+
+This agent session still sees the old injected `TRADING_DB_URL`. A fresh cloud
+agent session should pick up the corrected secret value if the environment has
+been updated successfully.
+
+## What the next engineer should do first
+
+In a fresh cloud agent session:
+
+1. Confirm the injected Trading DB URL now points to a public host:
+
+   ```bash
+   node - <<'JS'
+   const url = new URL(process.env.TRADING_DB_URL);
+   console.log(url.hostname, url.port || '(default)', url.pathname.slice(1));
+   JS
+   ```
+
+2. Confirm connectivity:
+
+   ```bash
+   psql "$TRADING_DB_URL" -Atqc "SELECT current_database(), current_user, inet_server_addr()::text, inet_server_port(), current_setting('server_version_num')"
+   ```
+
+3. Confirm there are no unexpected pending migrations:
+
+   ```bash
+   comm -23 <(ls lib/db-trading/migrations/*.sql | xargs -n1 basename | sort) <(psql "$TRADING_DB_URL" -Atqc "SELECT filename FROM public.schema_migrations_cursor ORDER BY filename" | sort) || true
+   ```
+
+4. Run the real remote Trading commands:
+
+   ```bash
+   pnpm --filter @lib/db-trading db:migrate
+   pnpm --filter @lib/db-trading db:verify
+   ```
+
+5. If `db:verify` produces tracked-file diffs, review them, run:
+
+   ```bash
+   pnpm build
+   ```
+
+   then commit and push the resulting artifacts on this branch.
+
+## Expected outcome in the fresh agent
+
+If the corrected `TRADING_DB_URL` is now public and reachable, all three
+packages should be able to run against their real remote databases:
+
+- `@lib/db-trading`
+- `@lib/db-marketing`
+- `@lib/db-timescale`
+
+## Relevant commits already on this branch
+
+- `a71e2bf` - `fix: stabilize db contract verification`
+- `da1ca46` - `fix: commit db contract artifacts`
+- `be911c9` - `docs: allow explicit remote db verification`

--- a/docs/db/management-playbook.md
+++ b/docs/db/management-playbook.md
@@ -5,6 +5,7 @@ monorepo.
 
 ## Packages and source of truth
 
+- `@lib/db-marketing` owns `MARKETING_DB_URL`
 - `@lib/db-trading` owns `TRADING_DB_URL`
 - `@lib/db-timescale` owns `TIMESCALE_DB_URL`
 - Source of truth is:
@@ -30,6 +31,7 @@ Always:
 
 Before running package scripts, export the correct DB URL:
 
+- Marketing: `MARKETING_DB_URL`
 - Postgres: `TRADING_DB_URL`
 - Timescale: `TIMESCALE_DB_URL`
 
@@ -46,6 +48,7 @@ server major versions do not match.
 For a brand-new empty database, use the normal migration flow:
 
 ```bash
+pnpm --filter @lib/db-marketing db:migrate
 pnpm --filter @lib/db-trading db:migrate
 pnpm --filter @lib/db-timescale db:migrate
 ```
@@ -59,6 +62,7 @@ Timescale note:
 
 Both DB packages include a baseline migration generated from the live DB:
 
+- `lib/db-marketing/migrations/202603141200__baseline.sql`
 - `lib/db-trading/migrations/202602180130__baseline.sql`
 - `lib/db-timescale/migrations/202602180131__baseline.sql`
 
@@ -66,6 +70,7 @@ For a database that already has the baseline schema, mark only the baseline as
 applied:
 
 ```bash
+pnpm --filter @lib/db-marketing db:migrate:baseline
 pnpm --filter @lib/db-trading db:migrate:baseline
 pnpm --filter @lib/db-timescale db:migrate:baseline
 ```
@@ -73,6 +78,7 @@ pnpm --filter @lib/db-timescale db:migrate:baseline
 After baselining, run the normal migration flow so later migrations still apply:
 
 ```bash
+pnpm --filter @lib/db-marketing db:migrate
 pnpm --filter @lib/db-trading db:migrate
 pnpm --filter @lib/db-timescale db:migrate
 ```
@@ -82,6 +88,7 @@ pnpm --filter @lib/db-timescale db:migrate
 Each DB package now has a contract verification command:
 
 ```bash
+pnpm --filter @lib/db-marketing db:verify
 pnpm --filter @lib/db-trading db:verify
 pnpm --filter @lib/db-timescale db:verify
 ```
@@ -96,6 +103,18 @@ Each command:
 
 The same verification commands run in CI against fresh Postgres and Timescale
 containers.
+
+`db:verify` is not read-only. It runs `db:migrate` first, so using it against a
+deployed remote database can apply pending migrations before regenerating local
+contract artifacts.
+
+Remote `db:migrate` / `db:verify` runs are allowed only with an explicit user
+request. Before running them from a cloud agent:
+
+1. confirm the corresponding `*_DB_URL` environment variable is present
+2. confirm the host is reachable from the current environment
+3. compare local migration files with `schema_migrations_cursor` and understand
+   any pending migrations before proceeding
 
 ## Creating a new migration
 
@@ -213,6 +232,7 @@ Example: add column `status` to `order_v1`.
 
 Generated files:
 
+- `lib/db-marketing/generated/typescript/db-types.ts`
 - `lib/db-trading/generated/typescript/db-types.ts`
 - `lib/db-timescale/generated/typescript/db-types.ts`
 
@@ -242,6 +262,15 @@ How to enforce:
 - [ ] `pnpm build` passes
 
 ## Script reference
+
+Marketing package:
+
+- `pnpm --filter @lib/db-marketing db:migration:new -- <name>`
+- `pnpm --filter @lib/db-marketing db:migrate`
+- `pnpm --filter @lib/db-marketing db:verify`
+- `pnpm --filter @lib/db-marketing db:migrate:baseline`
+- `pnpm --filter @lib/db-marketing db:schema:snapshot`
+- `pnpm --filter @lib/db-marketing db:types:generate`
 
 Postgres package:
 

--- a/docs/db/management-playbook.md
+++ b/docs/db/management-playbook.md
@@ -35,6 +35,12 @@ Before running package scripts, export the correct DB URL:
 
 The app `.env` files already contain these values.
 
+`db:schema:snapshot` and `db:verify` also require local PostgreSQL client tools.
+Match the client major version to the target DB server and CI. The current DB
+contract workflow runs PostgreSQL 17 service containers with PostgreSQL 17
+client tools, and the local snapshot scripts now fail fast if `pg_dump` and the
+server major versions do not match.
+
 ## First-time setup for fresh empty databases
 
 For a brand-new empty database, use the normal migration flow:

--- a/lib/db-marketing/AGENTS.md
+++ b/lib/db-marketing/AGENTS.md
@@ -30,6 +30,9 @@ Database-first package for the `MARKETING_DB_URL` database.
   `db:verify`.
 - Existing pre-migration DB with baseline schema already present: run
   `db:migrate:baseline` once, then `db:migrate`, then `db:verify`.
+- `db:verify` is not read-only; it runs `db:migrate` first.
+- Only run `db:migrate` / `db:verify` against a deployed remote DB when the
+  user explicitly requests it. Check connectivity and pending migrations first.
 - Never manually create or alter tables outside migrations.
 - Migration files are forward-only SQL; do not add `BEGIN` / `COMMIT`.
 - For populated tables, migrations must explicitly backfill data and explicitly

--- a/lib/db-marketing/README.md
+++ b/lib/db-marketing/README.md
@@ -23,6 +23,11 @@ Set:
 export MARKETING_DB_URL="postgres://..."
 ```
 
+`db:schema:snapshot` and `db:verify` require local PostgreSQL client tools.
+Use the same PostgreSQL major version as the target DB server and CI
+(`pg_dump`/`psql` 17 for the current workflow setup). The snapshot script fails
+fast if the local client major version does not match the server.
+
 ## Fresh empty database
 
 Use this flow for a brand-new empty Postgres database:
@@ -63,6 +68,9 @@ pnpm --filter @lib/db-marketing db:migrate
 ```bash
 pnpm --filter @lib/db-marketing db:verify
 ```
+
+`db:verify` is not read-only. It runs `db:migrate` first, then regenerates
+local contract artifacts and checks them with `git diff --exit-code`.
 
 ### Create a new migration
 

--- a/lib/db-marketing/schema/current.sql
+++ b/lib/db-marketing/schema/current.sql
@@ -3,8 +3,6 @@
 --
 
 
--- Dumped from database version 17.9 (Debian 17.9-1.pgdg13+1)
--- Dumped by pg_dump version 18.2
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/lib/db-marketing/scripts/snapshot-schema.sh
+++ b/lib/db-marketing/scripts/snapshot-schema.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+package_dir="$(cd "${script_dir}/.." && pwd)"
+repo_root="$(cd "${package_dir}/../.." && pwd)"
+
 if [[ -z "${MARKETING_DB_URL:-}" ]]; then
   echo "MARKETING_DB_URL is required"
   exit 1
 fi
+
+bash "${repo_root}/scripts/check-postgres-client-version.sh" MARKETING_DB_URL "@lib/db-marketing"
 
 pg_dump "$MARKETING_DB_URL" \
   --schema-only \
@@ -13,10 +19,12 @@ pg_dump "$MARKETING_DB_URL" \
   --no-privileges \
   --exclude-table=public.schema_migrations_cursor \
   | sed \
+      -e '/^-- Dumped from database version /d' \
+      -e '/^-- Dumped by pg_dump version /d' \
       -e '/^\\restrict /d' \
       -e '/^\\unrestrict /d' \
       -e '/^CREATE SCHEMA public;$/d' \
       -e "/^COMMENT ON SCHEMA public IS 'standard public schema';$/d" \
-  > schema/current.sql
+  > "${package_dir}/schema/current.sql"
 
 echo "Wrote schema/current.sql"

--- a/lib/db-marketing/scripts/verify-contract.mjs
+++ b/lib/db-marketing/scripts/verify-contract.mjs
@@ -187,4 +187,4 @@ run("git", [
   "generated/contracts/db-schema.json",
 ]);
 
-console.log("Postgres DB contract verification passed");
+console.log("Marketing DB contract verification passed");

--- a/lib/db-marketing/scripts/verify-contract.mjs
+++ b/lib/db-marketing/scripts/verify-contract.mjs
@@ -182,9 +182,9 @@ run("git", [
   "diff",
   "--exit-code",
   "--",
-  "lib/db-marketing/schema/current.sql",
-  "lib/db-marketing/generated/typescript/db-types.ts",
-  "lib/db-marketing/generated/contracts/db-schema.json",
+  "schema/current.sql",
+  "generated/typescript/db-types.ts",
+  "generated/contracts/db-schema.json",
 ]);
 
 console.log("Postgres DB contract verification passed");

--- a/lib/db-timescale/AGENTS.md
+++ b/lib/db-timescale/AGENTS.md
@@ -22,6 +22,8 @@ for TypeScript, Python, C#, and R.
 - Fresh empty DB: run `pnpm --filter @lib/db-timescale db:migrate`, then `db:verify`.
 - Existing pre-migration DB with baseline schema already present: run `db:migrate:baseline` once, then `db:migrate`, then `db:verify`.
 - The migration runner creates `timescaledb` if needed; the DB role must have permission to create extensions.
+- `db:verify` is not read-only; it runs `db:migrate` first.
+- Only run `db:migrate` / `db:verify` against a deployed remote DB when the user explicitly requests it. Check connectivity and pending migrations first.
 - Never manually create or alter tables outside migrations.
 - Migration files are forward-only SQL; do not add `BEGIN` / `COMMIT`.
 - For populated tables, migrations must explicitly backfill data and explicitly convert types with `USING` where needed.

--- a/lib/db-timescale/README.md
+++ b/lib/db-timescale/README.md
@@ -132,6 +132,9 @@ pnpm --filter @lib/db-timescale db:migrate
 pnpm --filter @lib/db-timescale db:verify
 ```
 
+`db:verify` is not read-only. It runs `db:migrate` first, then regenerates
+local contract artifacts and checks them with `git diff --exit-code`.
+
 ### Create a new migration
 
 ```bash

--- a/lib/db-timescale/README.md
+++ b/lib/db-timescale/README.md
@@ -29,6 +29,11 @@ Set:
 export TIMESCALE_DB_URL="postgres://..."
 ```
 
+`db:schema:snapshot` and `db:verify` require local PostgreSQL client tools.
+Use the same PostgreSQL major version as the target DB server and CI
+(`pg_dump`/`psql` 17 for the current GitHub Actions workflow). The snapshot
+script fails fast if the local client major version does not match the server.
+
 The target DB must support TimescaleDB. The migration runner executes:
 
 ```sql
@@ -185,4 +190,4 @@ This package is verified in GitHub Actions against a fresh Timescale container:
 - `AGENTS.md` - concise rules for engineers and AI agents
 - `migrations/README.md` - migration authoring details
 - `docs/db/management-playbook.md` - repo-wide DB workflow
-- `apps/write-node/README.md` - writer app workflow using this package
+- `apps-trading/write-node/README.md` - writer app workflow using this package

--- a/lib/db-timescale/schema/current.sql
+++ b/lib/db-timescale/schema/current.sql
@@ -2,10 +2,6 @@
 -- PostgreSQL database dump
 --
 
-
--- Dumped from database version 17.7
--- Dumped by pg_dump version 18.2
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;

--- a/lib/db-timescale/schema/current.sql
+++ b/lib/db-timescale/schema/current.sql
@@ -2,6 +2,8 @@
 -- PostgreSQL database dump
 --
 
+
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -31,41 +33,6 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
--- Name: candles_1m_1s; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.candles_1m_1s (
-    "time" timestamp with time zone NOT NULL,
-    ticker text NOT NULL,
-    open double precision NOT NULL,
-    high double precision NOT NULL,
-    low double precision NOT NULL,
-    close double precision NOT NULL,
-    volume double precision DEFAULT 0,
-    ask_volume double precision DEFAULT 0,
-    bid_volume double precision DEFAULT 0,
-    cvd_open double precision,
-    cvd_high double precision,
-    cvd_low double precision,
-    cvd_close double precision,
-    vd double precision,
-    trades integer DEFAULT 0 NOT NULL,
-    max_trade_size double precision DEFAULT 0 NOT NULL,
-    big_trades integer DEFAULT 0 NOT NULL,
-    big_volume double precision DEFAULT 0 NOT NULL,
-    symbol text,
-    vd_ratio double precision,
-    book_imbalance double precision,
-    price_pct double precision,
-    divergence double precision,
-    sum_bid_depth double precision DEFAULT 0 NOT NULL,
-    sum_ask_depth double precision DEFAULT 0 NOT NULL,
-    sum_price_volume double precision DEFAULT 0 NOT NULL,
-    unknown_volume double precision DEFAULT 0 NOT NULL
-);
-
-
---
 -- Name: candles_1h_1m; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -93,6 +60,41 @@ CREATE TABLE public.candles_1h_1m (
     max_trade_size double precision DEFAULT 0 NOT NULL,
     big_trades integer DEFAULT 0 NOT NULL,
     big_volume double precision DEFAULT 0 NOT NULL,
+    sum_bid_depth double precision DEFAULT 0 NOT NULL,
+    sum_ask_depth double precision DEFAULT 0 NOT NULL,
+    sum_price_volume double precision DEFAULT 0 NOT NULL,
+    unknown_volume double precision DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: candles_1m_1s; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.candles_1m_1s (
+    "time" timestamp with time zone NOT NULL,
+    ticker text NOT NULL,
+    open double precision NOT NULL,
+    high double precision NOT NULL,
+    low double precision NOT NULL,
+    close double precision NOT NULL,
+    volume double precision DEFAULT 0,
+    ask_volume double precision DEFAULT 0,
+    bid_volume double precision DEFAULT 0,
+    cvd_open double precision,
+    cvd_high double precision,
+    cvd_low double precision,
+    cvd_close double precision,
+    vd double precision,
+    trades integer DEFAULT 0 NOT NULL,
+    max_trade_size double precision DEFAULT 0 NOT NULL,
+    big_trades integer DEFAULT 0 NOT NULL,
+    big_volume double precision DEFAULT 0 NOT NULL,
+    symbol text,
+    vd_ratio double precision,
+    book_imbalance double precision,
+    price_pct double precision,
+    divergence double precision,
     sum_bid_depth double precision DEFAULT 0 NOT NULL,
     sum_ask_depth double precision DEFAULT 0 NOT NULL,
     sum_price_volume double precision DEFAULT 0 NOT NULL,

--- a/lib/db-timescale/scripts/snapshot-schema.sh
+++ b/lib/db-timescale/scripts/snapshot-schema.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+package_dir="$(cd "${script_dir}/.." && pwd)"
+repo_root="$(cd "${package_dir}/../.." && pwd)"
+
 if [[ -z "${TIMESCALE_DB_URL:-}" ]]; then
   echo "TIMESCALE_DB_URL is required"
   exit 1
 fi
+
+bash "${repo_root}/scripts/check-postgres-client-version.sh" TIMESCALE_DB_URL "@lib/db-timescale"
 
 pg_dump "$TIMESCALE_DB_URL" \
   --schema-only \
@@ -13,10 +19,12 @@ pg_dump "$TIMESCALE_DB_URL" \
   --no-privileges \
   --exclude-table=public.schema_migrations_cursor \
   | sed \
+      -e '/^-- Dumped from database version /d' \
+      -e '/^-- Dumped by pg_dump version /d' \
       -e '/^\\restrict /d' \
       -e '/^\\unrestrict /d' \
       -e '/^CREATE SCHEMA public;$/d' \
       -e "/^COMMENT ON SCHEMA public IS 'standard public schema';$/d" \
-  > schema/current.sql
+  > "${package_dir}/schema/current.sql"
 
 echo "Wrote schema/current.sql"

--- a/lib/db-timescale/scripts/verify-contract.mjs
+++ b/lib/db-timescale/scripts/verify-contract.mjs
@@ -92,9 +92,9 @@ run("git", [
   "diff",
   "--exit-code",
   "--",
-  "lib/db-timescale/schema/current.sql",
-  "lib/db-timescale/generated/typescript/db-types.ts",
-  "lib/db-timescale/generated/contracts/db-schema.json",
+  "schema/current.sql",
+  "generated/typescript/db-types.ts",
+  "generated/contracts/db-schema.json",
 ]);
 
 console.log("Timescale DB contract verification passed");

--- a/lib/db-trading/AGENTS.md
+++ b/lib/db-trading/AGENTS.md
@@ -20,6 +20,8 @@ Database-first package for the `TRADING_DB_URL` database.
 - Do not import `@lib/common` from this package. Runtime concerns like request IP lookup, response formatting, and SMS alerts belong in apps or `@lib/common`.
 - Fresh empty DB: run `pnpm --filter @lib/db-trading db:migrate`, then `db:verify`.
 - Existing pre-migration DB with baseline schema already present: run `db:migrate:baseline` once, then `db:migrate`, then `db:verify`.
+- `db:verify` is not read-only; it runs `db:migrate` first.
+- Only run `db:migrate` / `db:verify` against a deployed remote DB when the user explicitly requests it. Check connectivity and pending migrations first.
 - Never manually create or alter tables outside migrations.
 - Migration files are forward-only SQL; do not add `BEGIN` / `COMMIT`.
 - For populated tables, migrations must explicitly backfill data and explicitly convert types with `USING` where needed.

--- a/lib/db-trading/README.md
+++ b/lib/db-trading/README.md
@@ -105,6 +105,9 @@ pnpm --filter @lib/db-trading db:migrate
 pnpm --filter @lib/db-trading db:verify
 ```
 
+`db:verify` is not read-only. It runs `db:migrate` first, then regenerates
+local contract artifacts and checks them with `git diff --exit-code`.
+
 ### Create a new migration
 
 ```bash

--- a/lib/db-trading/README.md
+++ b/lib/db-trading/README.md
@@ -20,6 +20,11 @@ Set:
 export TRADING_DB_URL="postgres://..."
 ```
 
+`db:schema:snapshot` and `db:verify` require local PostgreSQL client tools.
+Use the same PostgreSQL major version as the target DB server and CI
+(`pg_dump`/`psql` 17 for the current GitHub Actions workflow). The snapshot
+script fails fast if the local client major version does not match the server.
+
 ## Fresh empty database
 
 Use this flow for a brand-new empty Postgres database:

--- a/lib/db-trading/generated/typescript/db-types.ts
+++ b/lib/db-trading/generated/typescript/db-types.ts
@@ -2,41 +2,41 @@
 // Run: pnpm --filter @lib/db-trading db:types:generate
 
 export interface LogV1Row {
-  id: number;
-  name: string | null;
-  message: string | null;
-  stack: unknown | null;
-  access_key: string | null;
-  server_name: string | null;
-  app_name: string | null;
-  node_env: string | null;
-  category: string | null;
-  tag: string | null;
-  time: Date | null;
-  created_at: Date | null;
+  "id": number;
+  "name": string | null;
+  "message": string | null;
+  "stack": unknown | null;
+  "access_key": string | null;
+  "server_name": string | null;
+  "app_name": string | null;
+  "node_env": string | null;
+  "category": string | null;
+  "tag": string | null;
+  "time": Date | null;
+  "created_at": Date | null;
 }
 
 export interface OrderV1Row {
-  id: number;
-  client_id: number | null;
-  type: string | null;
-  ticker: string | null;
-  side: string | null;
-  amount: number | null;
-  price: number | null;
-  server_name: string | null;
-  app_name: string | null;
-  node_env: string | null;
-  created_at: Date | null;
+  "id": number;
+  "client_id": number | null;
+  "type": string | null;
+  "ticker": string | null;
+  "side": string | null;
+  "amount": number | null;
+  "price": number | null;
+  "server_name": string | null;
+  "app_name": string | null;
+  "node_env": string | null;
+  "created_at": Date | null;
 }
 
 export interface StrengthV1Row {
-  id: number;
-  price: number | null;
-  volume: number | null;
-  ticker: string | null;
-  timenow: Date | null;
-  updated_at: Date | null;
+  "id": number;
+  "price": number | null;
+  "volume": number | null;
+  "ticker": string | null;
+  "timenow": Date | null;
+  "updated_at": Date | null;
   "240": number | null;
   "12": number | null;
   "4": number | null;
@@ -44,7 +44,7 @@ export interface StrengthV1Row {
   "30": number | null;
   "1": number | null;
   "2": number | null;
-  average: number | null;
+  "average": number | null;
   "5": number | null;
   "13": number | null;
   "39": number | null;
@@ -61,12 +61,12 @@ export interface StrengthV1Row {
   "29": number | null;
   "109": number | null;
   "181": number | null;
-  D: number | null;
-  W: number | null;
+  "D": number | null;
+  "W": number | null;
 }
 
 export interface PostgresDbSchema {
-  log_v1: LogV1Row;
-  order_v1: OrderV1Row;
-  strength_v1: StrengthV1Row;
+  "log_v1": LogV1Row;
+  "order_v1": OrderV1Row;
+  "strength_v1": StrengthV1Row;
 }

--- a/lib/db-trading/schema/current.sql
+++ b/lib/db-trading/schema/current.sql
@@ -2,9 +2,6 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 17.7 (Debian 17.7-3.pgdg13+1)
--- Dumped by pg_dump version 18.2
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;

--- a/lib/db-trading/schema/current.sql
+++ b/lib/db-trading/schema/current.sql
@@ -2,6 +2,8 @@
 -- PostgreSQL database dump
 --
 
+
+
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -13,6 +15,18 @@ SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
+
+--
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
+--
+
+
+
+--
+-- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: -
+--
+
+
 
 SET default_tablespace = '';
 
@@ -185,4 +199,10 @@ ALTER TABLE ONLY public.order_v1
 
 ALTER TABLE ONLY public.strength_v1
     ADD CONSTRAINT strength_v1_ticker_timenow_unique UNIQUE (ticker, timenow);
+
+
+--
+-- PostgreSQL database dump complete
+--
+
 

--- a/lib/db-trading/scripts/snapshot-schema.sh
+++ b/lib/db-trading/scripts/snapshot-schema.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+package_dir="$(cd "${script_dir}/.." && pwd)"
+repo_root="$(cd "${package_dir}/../.." && pwd)"
+
 if [[ -z "${TRADING_DB_URL:-}" ]]; then
   echo "TRADING_DB_URL is required"
   exit 1
 fi
+
+bash "${repo_root}/scripts/check-postgres-client-version.sh" TRADING_DB_URL "@lib/db-trading"
 
 pg_dump "$TRADING_DB_URL" \
   --schema-only \
@@ -13,10 +19,12 @@ pg_dump "$TRADING_DB_URL" \
   --no-privileges \
   --exclude-table=public.schema_migrations_cursor \
   | sed \
+      -e '/^-- Dumped from database version /d' \
+      -e '/^-- Dumped by pg_dump version /d' \
       -e '/^\\restrict /d' \
       -e '/^\\unrestrict /d' \
       -e '/^CREATE SCHEMA public;$/d' \
       -e "/^COMMENT ON SCHEMA public IS 'standard public schema';$/d" \
-  > schema/current.sql
+  > "${package_dir}/schema/current.sql"
 
 echo "Wrote schema/current.sql"

--- a/lib/db-trading/scripts/verify-contract.mjs
+++ b/lib/db-trading/scripts/verify-contract.mjs
@@ -61,4 +61,4 @@ run("git", [
   "lib/db-trading/generated/contracts/db-schema.json",
 ]);
 
-console.log("Postgres DB contract verification passed");
+console.log("Trading DB contract verification passed");

--- a/lib/db-trading/scripts/verify-contract.mjs
+++ b/lib/db-trading/scripts/verify-contract.mjs
@@ -56,9 +56,9 @@ run("git", [
   "diff",
   "--exit-code",
   "--",
-  "lib/db-trading/schema/current.sql",
-  "lib/db-trading/generated/typescript/db-types.ts",
-  "lib/db-trading/generated/contracts/db-schema.json",
+  "schema/current.sql",
+  "generated/typescript/db-types.ts",
+  "generated/contracts/db-schema.json",
 ]);
 
 console.log("Trading DB contract verification passed");

--- a/scripts/check-postgres-client-version.sh
+++ b/scripts/check-postgres-client-version.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <DATABASE_URL_ENV_VAR> <label>" >&2
+  exit 1
+fi
+
+database_url_env="$1"
+label="$2"
+database_url="${!database_url_env:-}"
+
+if [[ -z "$database_url" ]]; then
+  echo "${database_url_env} is required" >&2
+  exit 1
+fi
+
+if ! command -v psql >/dev/null 2>&1 || ! command -v pg_dump >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+PostgreSQL client tools are required to verify DB contracts.
+
+Install both `psql` and `pg_dump`, and make sure they match the same major
+version as the target database server before rerunning the command.
+
+Examples:
+  Ubuntu/Debian:
+    sudo apt-get install -y postgresql-common ca-certificates
+    sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+    sudo apt-get install -y postgresql-client-17
+
+  Homebrew:
+    brew install postgresql@17
+
+After installation, ensure `psql --version` and `pg_dump --version` report the
+same PostgreSQL major version as the DB server.
+EOF
+  exit 1
+fi
+
+server_major="$(
+  psql "$database_url" -Atqc "SELECT current_setting('server_version_num')::int / 10000"
+)"
+pg_dump_version="$(pg_dump --version)"
+client_major="$(
+  printf '%s\n' "$pg_dump_version" \
+    | sed -E 's/.* ([0-9]+)(\.[0-9]+)?([[:space:]].*)?$/\1/'
+)"
+
+if [[ -z "$server_major" || -z "$client_major" ]]; then
+  echo "Unable to determine PostgreSQL client/server major versions for ${label}" >&2
+  exit 1
+fi
+
+if [[ "$client_major" != "$server_major" ]]; then
+  cat >&2 <<EOF
+PostgreSQL client/server major version mismatch for ${label}.
+
+  server major: ${server_major}
+  pg_dump: ${pg_dump_version}
+
+Install PostgreSQL client ${server_major} locally so schema snapshots match the
+PostgreSQL ${server_major} service containers used in CI.
+
+Examples:
+  Ubuntu/Debian:
+    sudo apt-get install -y postgresql-common ca-certificates
+    sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+    sudo apt-get install -y postgresql-client-${server_major}
+
+  Homebrew:
+    brew install postgresql@${server_major}
+
+After installation, ensure `psql` and `pg_dump` resolve to PostgreSQL
+${server_major} before rerunning this command.
+EOF
+  exit 1
+fi
+
+echo "Using ${pg_dump_version} against ${label} server major ${server_major}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- rename the DB Contracts workflow check to "Verify Trading contract", install PostgreSQL 17 client tools in CI, and pin the PostgreSQL/Timescale service images and watched paths
- add a PostgreSQL client/server version preflight so local snapshot generation fails fast when `psql`/`pg_dump` do not match the target DB major version
- fix all DB package `db:verify` scripts to diff package-local artifact paths correctly so regenerated contract files can no longer slip past verification
- commit the regenerated trading and timescale contract artifacts produced by PostgreSQL 17 verification
- harden `@lib/db-marketing` with the same deterministic snapshot and client-version checks, and document when cloud agents may run remote `db:migrate` / `db:verify`
- verify the reachable deployed Marketing and Timescale databases directly from the cloud agent; confirm both already had all known migrations applied before running package commands
- add `docs/db/cloud-agent-handoff.md` with a step-by-step handoff for a fresh agent session to re-test the corrected remote Trading DB URL

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter @lib/db-trading db:migrate` with `TRADING_DB_URL=postgres://postgres:postgres@localhost:5432/app_contracts`
- `pnpm --filter @lib/db-trading db:verify` with `TRADING_DB_URL=postgres://postgres:postgres@localhost:5432/app_contracts`
- `pnpm --filter @lib/db-timescale db:migrate` with `TIMESCALE_DB_URL=postgres://postgres:postgres@localhost:5432/app_contracts_timescale`
- `pnpm --filter @lib/db-timescale db:verify` with `TIMESCALE_DB_URL=postgres://postgres:postgres@localhost:5432/app_contracts_timescale`
- `pnpm build`
- `pnpm --filter @lib/db-timescale db:migrate` against the deployed remote `TIMESCALE_DB_URL`
- `pnpm --filter @lib/db-timescale db:verify` against the deployed remote `TIMESCALE_DB_URL`
- `pnpm --filter @lib/db-marketing db:migrate` against the deployed remote `MARKETING_DB_URL`
- `pnpm --filter @lib/db-marketing db:verify` against the deployed remote `MARKETING_DB_URL`
- `pnpm build` after adding the handoff report

## Remote database access notes
- `TRADING_DB_URL` was present in this cloud environment, but this running agent still saw the old internal Railway hostname; a fresh agent session is needed to pick up the corrected secret
- the deployed Marketing and Timescale databases were reachable from the cloud environment and had no pending migrations before the remote runs
- `db:verify` is not read-only; it runs `db:migrate` first, then regenerates local contract artifacts and checks them with `git diff --exit-code`

## Local environment work performed in the cloud agent
- installed PostgreSQL 17 client tools (`psql`, `pg_dump`)
- installed a local PostgreSQL 17 server for trading contract verification
- installed TimescaleDB for PostgreSQL 17 and enabled it on the local cluster for fresh Timescale contract verification

## Fresh cloud session remote verification update
- confirmed `TRADING_DB_URL`, `MARKETING_DB_URL`, and `TIMESCALE_DB_URL` are all present and reachable from a fresh cloud session
- confirmed the injected Trading DB host is `tramway.proxy.rlwy.net`, not `postgres.railway.internal`
- preflight comparisons before each remote run found no pending local migrations or checksum mismatches in any package
- Trading has one remote-only ledger entry in `public.schema_migrations_cursor`: `202603141200__baseline.sql`; its checksum matches `lib/db-marketing/migrations/202603141200__baseline.sql`, but the actual Trading public schema still contains only `log_v1`, `order_v1`, `strength_v1`, and `schema_migrations_cursor`
- `pnpm --filter @lib/db-trading db:migrate` passed against the deployed Trading DB
- `pnpm --filter @lib/db-trading db:verify` passed against the deployed Trading DB
- `pnpm --filter @lib/db-marketing db:migrate` passed against the deployed Marketing DB
- `pnpm --filter @lib/db-marketing db:verify` passed against the deployed Marketing DB
- `pnpm --filter @lib/db-timescale db:migrate` passed against the deployed Timescale DB
- `pnpm --filter @lib/db-timescale db:verify` passed against the deployed Timescale DB
- no tracked DB contract artifacts changed after the fresh-session remote verification runs; the branch remained clean
- a repo-wide `pnpm build` was attempted in this cloud environment and is currently blocked by an existing unrelated workspace issue: `apps-marketing/eighthbrain-next/next.config.js` cannot resolve `@lib/config/next/base` during Turbo build
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1ff2b92-ca5c-4c61-b9d6-f47013f720ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1ff2b92-ca5c-4c61-b9d6-f47013f720ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

