### PR TITLE
Add PostgreSQL 17 client tools to cloud agent for DB contract verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,11 @@ In `lib/*` packages:
 - Use `pnpm --filter <app> <command>` or `cd apps/<app> && pnpm run <command>`
 - If request is ambiguous or contradictory, ask for clarification
 
+Cloud agent:
+
+- `cloud:install` installs PostgreSQL 17 client tools (psql, pg_dump) so
+  `db:migrate` and `db:verify` run in fresh sessions without manual apt setup.
+
 Remote DB operations:
 
 - `db:migrate` writes to the target database.

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -19,5 +19,21 @@ esac
 corepack enable
 corepack prepare pnpm@10.28.1 --activate
 
+# Install PostgreSQL 17 client tools (psql, pg_dump) for db:migrate and db:verify
+need_pg17=false
+if ! command -v psql >/dev/null 2>&1 || ! command -v pg_dump >/dev/null 2>&1; then
+  need_pg17=true
+elif ! pg_dump --version | grep -qE '\b17[.[]'; then
+  need_pg17=true
+fi
+if [[ "$need_pg17" == "true" ]]; then
+  echo "Installing PostgreSQL 17 client tools..."
+  sudo apt-get update -qq
+  sudo apt-get install -y postgresql-common ca-certificates
+  sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+  sudo apt-get install -y postgresql-client-17
+  echo "PostgreSQL client tools installed: $(pg_dump --version)"
+fi
+
 pnpm fetch --store-dir "$STORE_DIR"
 pnpm install --frozen-lockfile --prefer-offline --store-dir "$STORE_DIR"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds PostgreSQL 17 client tools (psql, pg_dump) to the cloud agent install script so `db:migrate` and `db:verify` run in fresh sessions without manual apt setup.

## Changes

- **scripts/cloud-agent-install.sh**: Install `postgresql-client-17` via PGDG apt repo when psql/pg_dump are missing or not version 17. Idempotent—skips install when tools already present.
- **AGENTS.md**: Document that `cloud:install` includes PostgreSQL 17 tools for DB contract verification.

## Verification

All six DB commands pass in the cloud workspace (with DB URLs configured):

- `pnpm --filter @lib/db-trading db:migrate`
- `pnpm --filter @lib/db-trading db:verify`
- `pnpm --filter @lib/db-marketing db:migrate`
- `pnpm --filter @lib/db-marketing db:verify`
- `pnpm --filter @lib/db-timescale db:migrate`
- `pnpm --filter @lib/db-timescale db:verify`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-596342bd-4fe5-4eca-b61c-2e24b89e37c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-596342bd-4fe5-4eca-b61c-2e24b89e37c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

