### PR TITLE
Add explicit second/minute candle columns

### DIFF
--- a/apps-trading/write-node/README.md
+++ b/apps-trading/write-node/README.md
@@ -197,6 +197,13 @@ Optional session-calendar env vars:
 - `MARKET_SESSION_OPEN_WINDOWS` - comma-separated weekly open windows in local
   session time (overrides the selected profile's windows), for example:
   `Sun 17:00-Mon 16:00, Mon 17:00-Tue 16:00, Tue 17:00-Wed 16:00, Wed 17:00-Thu 16:00, Thu 17:00-Fri 16:00`
+- `HOURLY_HEALTH_MAX_LAG_MINUTES` - optional maximum allowed `candles_1h_1m`
+  lag behind committed minute-boundary `candles_1m_1s` rows before `/api/v1/health`
+  returns unhealthy (default `2`)
+- `WRITE_PIPELINE_HEALTH_ALERT_INTERVAL_MS` - optional interval for in-process
+  stale/recovery health logs (default `60000`)
+- `WRITE_PIPELINE_HEALTH_STARTUP_GRACE_MS` - optional startup grace window before
+  stream readiness failures become unhealthy (default `120000`)
 
 Session profiles live in `src/lib/trade/market-session-config.ts`. Start by
 adding/adjusting entries in `SESSION_PROFILE_BY_TICKER`, then use
@@ -220,6 +227,11 @@ session calendar, not by fixed UTC close/reopen assumptions.
 On startup, the hourly writer hydrates itself from the most recent
 minute-boundary `candles_1m_1s` rows so it does not need a fresh 60-minute
 warmup.
+
+`/api/v1/health` now returns structured pipeline health instead of a bare
+boolean. It reports stream readiness, per-ticker source/target timestamps, and
+returns HTTP `503` when `candles_1h_1m` is stale beyond the configured lag
+threshold while the market is open.
 
 ## Developer rules
 

--- a/apps-trading/write-node/README.md
+++ b/apps-trading/write-node/README.md
@@ -5,8 +5,10 @@ Canonical futures timeseries writer.
 This app maintains:
 
 - `candles_1m_1s`: rolling 1-minute candles written every second from TBBO trades
+  with an explicit UTC `second` column
 - `candles_1h_1m`: rolling 1-hour candles written every minute from the
-  minute-boundary subset of `candles_1m_1s`
+  minute-boundary subset of `candles_1m_1s`, with an explicit UTC `minute`
+  column
 
 The shared rolling engine forward-fills short no-trade gaps as zero-volume
 seconds so minute-boundary rows stay available for the hourly layer. Extended

--- a/apps-trading/write-node/README.md
+++ b/apps-trading/write-node/README.md
@@ -163,6 +163,8 @@ pnpm --filter write-node historical:1h1m --truncate
 
 Notes:
 
+- `historical:tbbo` writes canonical `candles_1m_1s` rows and advances
+  `candles_1h_1m` from the committed minute-boundary subset during the same run
 - `historical:1h1m` reads only minute-boundary rows from `candles_1m_1s`
 - `--truncate` is recommended for a full deterministic rebuild
 - without `--truncate`, the script upserts into `candles_1h_1m`
@@ -207,6 +209,10 @@ Live behavior:
 1. raw TBBO trades -> `candles_1m_1s`
 2. successful 1m writes at minute boundaries feed the hourly aggregator
 3. minute-boundary rows -> `candles_1h_1m`
+
+The hourly writer also performs continuous runtime reconciliation from canonical
+minute-boundary `candles_1m_1s` rows so missed handoffs can be replayed without
+waiting for a process restart.
 
 The live stream gates trades by the trade event timestamp in the configured
 session calendar, not by fixed UTC close/reopen assumptions.

--- a/apps-trading/write-node/README.md
+++ b/apps-trading/write-node/README.md
@@ -204,6 +204,13 @@ Optional session-calendar env vars:
   stale/recovery health logs (default `60000`)
 - `WRITE_PIPELINE_HEALTH_STARTUP_GRACE_MS` - optional startup grace window before
   stream readiness failures become unhealthy (default `120000`)
+- `WRITE_PIPELINE_UNHEALTHY_RESTART_AFTER_MS` - optional duration that hourly lag
+  must remain unhealthy before the service logs the event, sends SMS, and exits
+  non-zero for platform restart (default `180000`)
+- `TRADING_DB_URL` - required if you want automatic remediation events persisted
+  via `sqlLogAdd`
+- `TWILLIO_USERNAME_PASSWORD` - required if you want automatic remediation events
+  sent by SMS
 
 Session profiles live in `src/lib/trade/market-session-config.ts`. Start by
 adding/adjusting entries in `SESSION_PROFILE_BY_TICKER`, then use
@@ -232,6 +239,10 @@ warmup.
 boolean. It reports stream readiness, per-ticker source/target timestamps, and
 returns HTTP `503` when `candles_1h_1m` is stale beyond the configured lag
 threshold while the market is open.
+
+If unhealthy hourly lag persists beyond the configured remediation window, the
+service will log the event, send an SMS alert, and exit non-zero so the hosting
+platform can restart it.
 
 ## Developer rules
 

--- a/apps-trading/write-node/docs/data-storage/1m-base-1h-aggregate.sql
+++ b/apps-trading/write-node/docs/data-storage/1m-base-1h-aggregate.sql
@@ -38,6 +38,8 @@ CREATE TABLE candles_1h_1m (
   sum_ask_depth    DOUBLE PRECISION NOT NULL DEFAULT 0,
   sum_price_volume DOUBLE PRECISION NOT NULL DEFAULT 0,
   unknown_volume   DOUBLE PRECISION NOT NULL DEFAULT 0,
+  minute           SMALLINT         NOT NULL,
+  CHECK (minute BETWEEN 0 AND 59),
   PRIMARY KEY (ticker, time)
 );
 

--- a/apps-trading/write-node/docs/data-storage/1s-base-1m-aggregate.sql
+++ b/apps-trading/write-node/docs/data-storage/1s-base-1m-aggregate.sql
@@ -41,6 +41,8 @@ CREATE TABLE candles_1m_1s (
   sum_ask_depth    DOUBLE PRECISION NOT NULL DEFAULT 0,
   sum_price_volume DOUBLE PRECISION NOT NULL DEFAULT 0,
   unknown_volume   DOUBLE PRECISION NOT NULL DEFAULT 0,
+  second           SMALLINT         NOT NULL,
+  CHECK (second BETWEEN 0 AND 59),
   PRIMARY KEY (ticker, time)
 );
 

--- a/apps-trading/write-node/docs/data-storage/candles-schema.md
+++ b/apps-trading/write-node/docs/data-storage/candles-schema.md
@@ -30,6 +30,7 @@ Each row is:
 
 - one ticker
 - one second timestamp
+- one explicit `second` column storing the UTC second within that minute
 - the trailing 60-second rolling window ending at that second
 
 The shared 1m engine forward-fills short no-trade gaps as zero-volume seconds so
@@ -45,6 +46,7 @@ Each row is:
 
 - one ticker
 - one minute timestamp
+- one explicit `minute` column storing the UTC minute within that hour
 - the trailing 60-minute rolling window ending at that minute
 
 This table is built only from the minute-boundary subset of canonical
@@ -102,6 +104,11 @@ inputs needed to derive VWAP when reading.
 | --- | --- | --- |
 | `candles_1m_1s` | second timestamp | trailing 60 seconds |
 | `candles_1h_1m` | minute timestamp | trailing 60 minutes |
+
+For explicit boundary queries, the writer also persists:
+
+- `candles_1m_1s.second` = UTC second bucket (`0`-`59`)
+- `candles_1h_1m.minute` = UTC minute bucket (`0`-`59`)
 
 ## Why additive accumulators are stored
 

--- a/apps-trading/write-node/package.json
+++ b/apps-trading/write-node/package.json
@@ -18,7 +18,9 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@lib/common": "workspace:*",
     "@lib/db-timescale": "workspace:*",
+    "@lib/db-trading": "workspace:*",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",

--- a/apps-trading/write-node/scripts/AGENTS.md
+++ b/apps-trading/write-node/scripts/AGENTS.md
@@ -10,7 +10,8 @@ Important details:
 - spread contracts such as `ESZ5-ESH6` are skipped
 - the batch script should stay behaviorally aligned with the live stream path
 - the batch script is part of the canonical source-of-truth writer pipeline
-- after `tbbo-1m-1s.ts` fills `candles_1m_1s`, `candles-1h-1m.ts` can rebuild `candles_1h_1m`
+- `tbbo-1m-1s.ts` should keep `candles_1h_1m` advancing from newly written minute-boundary `candles_1m_1s` rows
+- `candles-1h-1m.ts` remains the deterministic rebuild/repair path for `candles_1h_1m`
 
 ```
 {"ts_recv":"2025-11-30T23:00:00.039353882Z","hd":{"ts_event":"2025-11-30T23:00:00.000000000Z","rtype":1,"publisher_id":1,"instrument_id":42140878},"action":"T","side":"N","depth":0,"price":"6913.500000000","size":1,"flags":0,"ts_in_delta":13803,"sequence":3353,"levels":[{"bid_px":"6915.750000000","ask_px":"6913.000000000","bid_sz":1,"ask_sz":1,"bid_ct":1,"ask_ct":1}],"symbol":"ESH6"}

--- a/apps-trading/write-node/scripts/tbbo-1m-1s.ts
+++ b/apps-trading/write-node/scripts/tbbo-1m-1s.ts
@@ -34,6 +34,7 @@ import "dotenv/config";
 import { createReadStream } from "fs";
 import { createInterface } from "readline";
 import { pool } from "../src/lib/db.js";
+import { Candles1h1mAggregator } from "../src/stream/candles-1h-1m-aggregator.js";
 import type { NormalizedTrade, TimedTradeInput } from "../src/lib/trade/index.js";
 import {
   RollingWindow1m,
@@ -79,12 +80,14 @@ const LOG_INTERVAL = 100_000;
 const WINDOW_SECONDS = 60;
 
 const rollingWindow = new RollingWindow1m();
+const hourlyAggregator = new Candles1h1mAggregator();
 
 const stats = {
   filesProcessed: 0,
   linesProcessed: 0,
   tradesProcessed: 0,
   candlesWritten: 0,
+  hourlyCandlesWritten: 0,
   skippedNonTrade: 0,
   skippedSpreads: 0,
   unknownSide: 0,
@@ -189,8 +192,12 @@ async function flushPendingCandles(): Promise<void> {
   for (let i = 0; i < pendingCandles.length; i += BATCH_SIZE) {
     const batch = pendingCandles.slice(i, i + BATCH_SIZE);
     await writeCandles(pool, TARGET_TABLE, batch);
+    await hourlyAggregator.addBaseCandles(batch);
+    await hourlyAggregator.flushCompleted();
     stats.candlesWritten += batch.length;
   }
+
+  stats.hourlyCandlesWritten = hourlyAggregator.getCandlesWritten();
 
   console.log(`💾 Flushed ${pendingCandles.length} rolling 1m candle(s) to ${TARGET_TABLE}`);
 }
@@ -256,6 +263,7 @@ function printSummary(): void {
   console.log(`   Trades processed:      ${stats.tradesProcessed.toLocaleString()}`);
   console.log(`   1-second buckets:      ${rollingStats.secondsProcessed.toLocaleString()}`);
   console.log(`   1-minute candles:      ${stats.candlesWritten.toLocaleString()}`);
+  console.log(`   1-hour candles:        ${stats.hourlyCandlesWritten.toLocaleString()}`);
   console.log(`   Skipped (warmup):      ${rollingStats.candlesSkippedWarmup.toLocaleString()}`);
   console.log(`   Synthetic seconds:     ${rollingStats.syntheticSecondsFilled.toLocaleString()}`);
   console.log(`   Gap resets:            ${rollingStats.gapResets.toLocaleString()}`);
@@ -302,11 +310,14 @@ async function main(): Promise<void> {
   console.log("");
 
   await loadCvdFromDatabase();
+  await hourlyAggregator.initialize();
 
   for (const file of files) {
     await processFile(file);
   }
 
+  await hourlyAggregator.flushAll();
+  stats.hourlyCandlesWritten = hourlyAggregator.getCandlesWritten();
   printSummary();
   await pool.end();
 }

--- a/apps-trading/write-node/src/index.ts
+++ b/apps-trading/write-node/src/index.ts
@@ -2,16 +2,79 @@ import "dotenv/config";
 import express from "express";
 import cors from "cors";
 import { pool } from "./lib/db.js";
-import { startDatabentoStream, stopDatabentoStream } from "./stream/tbbo-stream.js";
+import { getWritePipelineHealth } from "./lib/health/write-pipeline-health.js";
+import { getStreamStats, getStreamStatus, startDatabentoStream, stopDatabentoStream } from "./stream/tbbo-stream.js";
 
 const app = express();
 const port = Number(process.env.PORT) || 8080;
+const maxAllowedLagMinutes = Number(process.env.HOURLY_HEALTH_MAX_LAG_MINUTES || "2");
+const healthAlertIntervalMs = Number(process.env.WRITE_PIPELINE_HEALTH_ALERT_INTERVAL_MS || "60000");
+const healthStartupGraceMs = Number(process.env.WRITE_PIPELINE_HEALTH_STARTUP_GRACE_MS || "120000");
 let shuttingDown = false;
+let healthMonitorTimer: NodeJS.Timeout | null = null;
+let lastHealthSnapshot = "";
 
 app.use(cors());
 
-app.get("/api/v1/health", (_req, res) => {
-  res.json(true);
+async function buildWritePipelineHealth() {
+  return getWritePipelineHealth({
+    queryable: pool,
+    streamStatus: getStreamStatus(),
+    streamStats: getStreamStats(),
+    maxAllowedLagMinutes,
+    processUptimeMs: process.uptime() * 1000,
+    startupGraceMs: healthStartupGraceMs,
+  });
+}
+
+async function checkWritePipelineHealthAndLog(): Promise<void> {
+  try {
+    const report = await buildWritePipelineHealth();
+    const snapshot = `${report.status}|${report.reasons.join("||")}|${report.lag.staleTickers.join(",")}|${report.lag.warmingUpTickers.join(",")}`;
+
+    if (snapshot === lastHealthSnapshot) {
+      return;
+    }
+
+    if (!report.ok) {
+      console.warn(
+        `⚠️ Write pipeline unhealthy: ${report.reasons.join(" | ")} ` +
+          `(stale: ${report.lag.staleTickers.join(", ") || "none"})`,
+      );
+    } else if (report.status === "warming_up") {
+      const warmingUpDetails =
+        report.lag.warmingUpTickers.length > 0
+          ? `hourly candles for: ${report.lag.warmingUpTickers.join(", ")}`
+          : `stream startup grace active (${report.stream.processUptimeSeconds}s uptime)`;
+      console.log(`⏳ Write pipeline warming up ${warmingUpDetails}`);
+    } else if (lastHealthSnapshot !== "") {
+      console.log("✅ Write pipeline health recovered");
+    }
+
+    lastHealthSnapshot = snapshot;
+  } catch (error) {
+    const snapshot = "error";
+    if (snapshot === lastHealthSnapshot) {
+      return;
+    }
+    console.error("❌ Write pipeline health check failed:", error);
+    lastHealthSnapshot = snapshot;
+  }
+}
+
+app.get("/api/v1/health", async (_req, res) => {
+  try {
+    const report = await buildWritePipelineHealth();
+    res.status(report.ok ? 200 : 503).json(report);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    res.status(503).json({
+      ok: false,
+      status: "unhealthy",
+      checkedAt: new Date().toISOString(),
+      reasons: [`health check failed: ${message}`],
+    });
+  }
 });
 
 const startStreamWithRetry = async () => {
@@ -29,6 +92,14 @@ const startStreamWithRetry = async () => {
 const server = app.listen(port, "::", () => {
   console.log(`🚀 Market write pipeline running on port ${port}`);
   console.log(`   Environment: ${process.env.RAILWAY_ENVIRONMENT_NAME || "local"}`);
+  if (healthMonitorTimer) {
+    clearInterval(healthMonitorTimer);
+  }
+  healthMonitorTimer = setInterval(() => {
+    void checkWritePipelineHealthAndLog();
+  }, healthAlertIntervalMs);
+  healthMonitorTimer.unref();
+  void checkWritePipelineHealthAndLog();
   void startStreamWithRetry();
 });
 
@@ -41,6 +112,10 @@ const shutdown = async (signal: string) => {
   console.log(`${signal} received, shutting down gracefully...`);
 
   server.close();
+  if (healthMonitorTimer) {
+    clearInterval(healthMonitorTimer);
+    healthMonitorTimer = null;
+  }
   await stopDatabentoStream();
   await pool.end();
   process.exit(0);

--- a/apps-trading/write-node/src/index.ts
+++ b/apps-trading/write-node/src/index.ts
@@ -2,6 +2,7 @@ import "dotenv/config";
 import express from "express";
 import cors from "cors";
 import { pool } from "./lib/db.js";
+import { evaluateHourlyLagRemediation, notifyHourlyLagRemediation } from "./lib/health/hourly-lag-remediation.js";
 import { getWritePipelineHealth } from "./lib/health/write-pipeline-health.js";
 import { getStreamStats, getStreamStatus, startDatabentoStream, stopDatabentoStream } from "./stream/tbbo-stream.js";
 
@@ -10,9 +11,12 @@ const port = Number(process.env.PORT) || 8080;
 const maxAllowedLagMinutes = Number(process.env.HOURLY_HEALTH_MAX_LAG_MINUTES || "2");
 const healthAlertIntervalMs = Number(process.env.WRITE_PIPELINE_HEALTH_ALERT_INTERVAL_MS || "60000");
 const healthStartupGraceMs = Number(process.env.WRITE_PIPELINE_HEALTH_STARTUP_GRACE_MS || "120000");
+const hourlyLagRemediationAfterMs = Number(process.env.WRITE_PIPELINE_UNHEALTHY_RESTART_AFTER_MS || "180000");
 let shuttingDown = false;
 let healthMonitorTimer: NodeJS.Timeout | null = null;
 let lastHealthSnapshot = "";
+let unhealthyLagSinceMs: number | null = null;
+let remediationInProgress = false;
 
 app.use(cors());
 
@@ -30,9 +34,19 @@ async function buildWritePipelineHealth() {
 async function checkWritePipelineHealthAndLog(): Promise<void> {
   try {
     const report = await buildWritePipelineHealth();
+    const remediationDecision = evaluateHourlyLagRemediation({
+      report,
+      nowMs: Date.now(),
+      remediationAfterMs: hourlyLagRemediationAfterMs,
+      unhealthyLagSinceMs,
+      remediationInProgress,
+    });
+    unhealthyLagSinceMs = remediationDecision.unhealthyLagSinceMs;
+    remediationInProgress = remediationDecision.remediationInProgress;
     const snapshot = `${report.status}|${report.reasons.join("||")}|${report.lag.staleTickers.join(",")}|${report.lag.warmingUpTickers.join(",")}`;
 
     if (snapshot === lastHealthSnapshot) {
+      await maybeRemediatePersistentHourlyLag(report, remediationDecision.shouldRemediate);
       return;
     }
 
@@ -52,6 +66,7 @@ async function checkWritePipelineHealthAndLog(): Promise<void> {
     }
 
     lastHealthSnapshot = snapshot;
+    await maybeRemediatePersistentHourlyLag(report, remediationDecision.shouldRemediate);
   } catch (error) {
     const snapshot = "error";
     if (snapshot === lastHealthSnapshot) {
@@ -60,6 +75,25 @@ async function checkWritePipelineHealthAndLog(): Promise<void> {
     console.error("❌ Write pipeline health check failed:", error);
     lastHealthSnapshot = snapshot;
   }
+}
+
+async function maybeRemediatePersistentHourlyLag(report: Awaited<ReturnType<typeof buildWritePipelineHealth>>, shouldRemediate: boolean) {
+  if (!shouldRemediate || unhealthyLagSinceMs === null || shuttingDown) {
+    return;
+  }
+
+  const confirmationReport = await buildWritePipelineHealth();
+  if (!(confirmationReport.status === "unhealthy" && confirmationReport.lag.staleTickers.length > 0)) {
+    unhealthyLagSinceMs = null;
+    remediationInProgress = false;
+    return;
+  }
+
+  await notifyHourlyLagRemediation({
+    report: confirmationReport,
+    unhealthyLagSinceMs,
+  });
+  await shutdown("AUTO_REMEDIATION", 1);
 }
 
 app.get("/api/v1/health", async (_req, res) => {
@@ -103,22 +137,31 @@ const server = app.listen(port, "::", () => {
   void startStreamWithRetry();
 });
 
-const shutdown = async (signal: string) => {
+const shutdown = async (signal: string, exitCode = 0) => {
   if (shuttingDown) {
     return;
   }
 
   shuttingDown = true;
   console.log(`${signal} received, shutting down gracefully...`);
+  const forceExitTimer = setTimeout(() => {
+    console.error(`Forcing process exit after delayed shutdown (${signal})`);
+    process.exit(exitCode);
+  }, 30_000);
+  forceExitTimer.unref();
 
-  server.close();
-  if (healthMonitorTimer) {
-    clearInterval(healthMonitorTimer);
-    healthMonitorTimer = null;
+  try {
+    server.close();
+    if (healthMonitorTimer) {
+      clearInterval(healthMonitorTimer);
+      healthMonitorTimer = null;
+    }
+    await stopDatabentoStream();
+    await pool.end();
+  } finally {
+    clearTimeout(forceExitTimer);
   }
-  await stopDatabentoStream();
-  await pool.end();
-  process.exit(0);
+  process.exit(exitCode);
 };
 
 process.on("SIGTERM", () => {

--- a/apps-trading/write-node/src/lib/health/hourly-lag-remediation.test.ts
+++ b/apps-trading/write-node/src/lib/health/hourly-lag-remediation.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  evaluateHourlyLagRemediation,
+  HOURLY_LAG_REMEDIATION_MESSAGE,
+  notifyHourlyLagRemediation,
+} from "./hourly-lag-remediation.js";
+import type { WritePipelineHealthReport } from "./write-pipeline-health.js";
+
+function makeReport(overrides: Partial<WritePipelineHealthReport> = {}): WritePipelineHealthReport {
+  return {
+    ok: false,
+    status: "unhealthy",
+    checkedAt: "2026-03-17T19:00:00.000Z",
+    reasons: ["candles_1h_1m is stale for: ES"],
+    stream: {
+      connected: true,
+      authenticated: true,
+      streaming: true,
+      reconnectAttempts: 0,
+      marketOpen: true,
+      marketOpenByTicker: { ES: true },
+      messagesReceived: 100,
+      parseErrors: 0,
+      skippedMarketClosed: 0,
+      startupGraceActive: false,
+      processUptimeSeconds: 600,
+    },
+    lag: {
+      maxAllowedLagMinutes: 2,
+      tickers: [
+        {
+          ticker: "ES",
+          marketOpen: true,
+          status: "stale",
+          latestSourceTime: "2026-03-17T18:59:00.000Z",
+          latestTargetTime: "2026-03-17T18:50:00.000Z",
+          latestSourceRowCount: 60,
+          lagMinutes: 9,
+        },
+      ],
+      staleTickers: ["ES"],
+      warmingUpTickers: [],
+    },
+    ...overrides,
+  };
+}
+
+test("starts tracking persisted unhealthy hourly lag before remediation", () => {
+  const nowMs = Date.parse("2026-03-17T19:00:00.000Z");
+  const decision = evaluateHourlyLagRemediation({
+    report: makeReport(),
+    nowMs,
+    remediationAfterMs: 180_000,
+    unhealthyLagSinceMs: null,
+    remediationInProgress: false,
+  });
+
+  assert.equal(decision.shouldRemediate, false);
+  assert.equal(decision.unhealthyLagSinceMs, nowMs);
+  assert.equal(decision.remediationInProgress, false);
+  assert.equal(decision.unhealthyLagDurationMs, 0);
+});
+
+test("triggers remediation once unhealthy lag persists past threshold", () => {
+  const unhealthyLagSinceMs = Date.parse("2026-03-17T18:56:00.000Z");
+  const nowMs = Date.parse("2026-03-17T19:00:00.000Z");
+  const decision = evaluateHourlyLagRemediation({
+    report: makeReport(),
+    nowMs,
+    remediationAfterMs: 180_000,
+    unhealthyLagSinceMs,
+    remediationInProgress: false,
+  });
+
+  assert.equal(decision.shouldRemediate, true);
+  assert.equal(decision.remediationInProgress, true);
+  assert.equal(decision.unhealthyLagDurationMs, 240_000);
+});
+
+test("resets remediation tracking after hourly lag recovers", () => {
+  const decision = evaluateHourlyLagRemediation({
+    report: makeReport({
+      ok: true,
+      status: "ok",
+      reasons: [],
+      lag: {
+        maxAllowedLagMinutes: 2,
+        tickers: [],
+        staleTickers: [],
+        warmingUpTickers: [],
+      },
+    }),
+    nowMs: Date.parse("2026-03-17T19:00:00.000Z"),
+    remediationAfterMs: 180_000,
+    unhealthyLagSinceMs: Date.parse("2026-03-17T18:56:00.000Z"),
+    remediationInProgress: false,
+  });
+
+  assert.equal(decision.shouldRemediate, false);
+  assert.equal(decision.unhealthyLagSinceMs, null);
+  assert.equal(decision.remediationInProgress, false);
+});
+
+test("notifies DB log and SMS with the remediation message", async () => {
+  let loggedRow: Record<string, unknown> | null = null;
+  let smsMessage = "";
+
+  await notifyHourlyLagRemediation({
+    report: makeReport(),
+    unhealthyLagSinceMs: Date.parse("2026-03-17T18:56:00.000Z"),
+    nowMs: Date.parse("2026-03-17T19:00:00.000Z"),
+    sqlLogAddFn: async (row) => {
+      loggedRow = row as unknown as Record<string, unknown>;
+      return null;
+    },
+    sendToMyselfSmsFn: async (message) => {
+      smsMessage = message;
+      return true;
+    },
+  });
+
+  assert.ok(loggedRow);
+  const persistedRow = loggedRow as Record<string, unknown>;
+  assert.equal(persistedRow.message, HOURLY_LAG_REMEDIATION_MESSAGE);
+  assert.equal(persistedRow.name, "error");
+  assert.equal(smsMessage, HOURLY_LAG_REMEDIATION_MESSAGE);
+  assert.deepEqual((persistedRow.stack as Record<string, unknown>).staleTickers, ["ES"]);
+});
+
+test("still attempts SMS when DB logging fails", async () => {
+  let smsMessage = "";
+
+  await notifyHourlyLagRemediation({
+    report: makeReport(),
+    unhealthyLagSinceMs: Date.parse("2026-03-17T18:56:00.000Z"),
+    sqlLogAddFn: async () => {
+      throw new Error("log failed");
+    },
+    sendToMyselfSmsFn: async (message) => {
+      smsMessage = message;
+      return true;
+    },
+  });
+
+  assert.equal(smsMessage, HOURLY_LAG_REMEDIATION_MESSAGE);
+});

--- a/apps-trading/write-node/src/lib/health/hourly-lag-remediation.ts
+++ b/apps-trading/write-node/src/lib/health/hourly-lag-remediation.ts
@@ -1,0 +1,113 @@
+import { sqlLogAdd } from "@lib/db-trading/sql/log/add";
+import { sendToMyselfSMS } from "@lib/common/twillio/sendToMyselfSMS";
+
+import type { WritePipelineHealthReport } from "./write-pipeline-health.js";
+
+export const HOURLY_LAG_REMEDIATION_MESSAGE =
+  "write-next automatic self-restart / remediation because hourly lag unhealthy";
+
+type SqlLogAddFn = typeof sqlLogAdd;
+type SendToMyselfSmsFn = typeof sendToMyselfSMS;
+
+export interface HourlyLagRemediationState {
+  unhealthyLagSinceMs: number | null;
+  remediationInProgress: boolean;
+}
+
+export interface HourlyLagRemediationDecision extends HourlyLagRemediationState {
+  shouldRemediate: boolean;
+  unhealthyLagDurationMs: number;
+}
+
+export interface EvaluateHourlyLagRemediationArgs extends HourlyLagRemediationState {
+  report: WritePipelineHealthReport;
+  nowMs: number;
+  remediationAfterMs: number;
+}
+
+export interface NotifyHourlyLagRemediationArgs {
+  report: WritePipelineHealthReport;
+  unhealthyLagSinceMs: number;
+  nowMs?: number;
+  sqlLogAddFn?: SqlLogAddFn;
+  sendToMyselfSmsFn?: SendToMyselfSmsFn;
+}
+
+function isHourlyLagUnhealthy(report: WritePipelineHealthReport): boolean {
+  return report.status === "unhealthy" && report.lag.staleTickers.length > 0;
+}
+
+export function evaluateHourlyLagRemediation({
+  report,
+  nowMs,
+  remediationAfterMs,
+  unhealthyLagSinceMs,
+  remediationInProgress,
+}: EvaluateHourlyLagRemediationArgs): HourlyLagRemediationDecision {
+  if (remediationInProgress) {
+    return {
+      unhealthyLagSinceMs,
+      remediationInProgress,
+      shouldRemediate: false,
+      unhealthyLagDurationMs: unhealthyLagSinceMs === null ? 0 : Math.max(0, nowMs - unhealthyLagSinceMs),
+    };
+  }
+
+  if (!isHourlyLagUnhealthy(report)) {
+    return {
+      unhealthyLagSinceMs: null,
+      remediationInProgress: false,
+      shouldRemediate: false,
+      unhealthyLagDurationMs: 0,
+    };
+  }
+
+  const nextUnhealthyLagSinceMs = unhealthyLagSinceMs ?? nowMs;
+  const unhealthyLagDurationMs = Math.max(0, nowMs - nextUnhealthyLagSinceMs);
+  const shouldRemediate = unhealthyLagDurationMs >= remediationAfterMs;
+
+  return {
+    unhealthyLagSinceMs: nextUnhealthyLagSinceMs,
+    remediationInProgress: shouldRemediate,
+    shouldRemediate,
+    unhealthyLagDurationMs,
+  };
+}
+
+export async function notifyHourlyLagRemediation({
+  report,
+  unhealthyLagSinceMs,
+  nowMs = Date.now(),
+  sqlLogAddFn = sqlLogAdd,
+  sendToMyselfSmsFn = sendToMyselfSMS,
+}: NotifyHourlyLagRemediationArgs): Promise<void> {
+  const debuggingData = {
+    category: "write-node-health",
+    tag: "hourly-lag-remediation",
+    checkedAt: report.checkedAt,
+    reasons: report.reasons,
+    staleTickers: report.lag.staleTickers,
+    unhealthyLagSince: new Date(unhealthyLagSinceMs).toISOString(),
+    unhealthyLagDurationMs: Math.max(0, nowMs - unhealthyLagSinceMs),
+    stream: report.stream,
+    lag: report.lag,
+    pid: process.pid,
+    uptimeSeconds: Math.round(process.uptime()),
+  };
+
+  try {
+    await sqlLogAddFn({
+      name: "error",
+      message: HOURLY_LAG_REMEDIATION_MESSAGE,
+      stack: debuggingData,
+    });
+  } catch (error) {
+    console.error("Failed to log hourly lag remediation event:", error);
+  }
+
+  try {
+    await sendToMyselfSmsFn(HOURLY_LAG_REMEDIATION_MESSAGE);
+  } catch (error) {
+    console.error("Failed to send hourly lag remediation SMS:", error);
+  }
+}

--- a/apps-trading/write-node/src/lib/health/write-pipeline-health.test.ts
+++ b/apps-trading/write-node/src/lib/health/write-pipeline-health.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getWritePipelineHealth } from "./write-pipeline-health.js";
+
+const baseStreamStatus = {
+  connected: true,
+  authenticated: true,
+  streaming: true,
+  reconnectAttempts: 0,
+};
+
+const baseStreamStats = {
+  marketOpen: true,
+  marketOpenByTicker: {
+    ES: true,
+  },
+  messagesReceived: 100,
+  parseErrors: 0,
+  skippedMarketClosed: 0,
+};
+
+test("reports healthy when hourly lag stays within threshold", async () => {
+  const report = await getWritePipelineHealth({
+    queryable: {
+      query: async <Row = unknown>() => ({
+        rows: [
+          {
+            ticker: "ES",
+            latest_source_time: "2026-03-17T18:53:00.000Z",
+            latest_source_row_count: 60,
+            latest_target_time: "2026-03-17T18:52:00.000Z",
+          },
+        ] as Row[],
+      }),
+    },
+    streamStatus: baseStreamStatus,
+    streamStats: baseStreamStats,
+    maxAllowedLagMinutes: 2,
+    processUptimeMs: 180_000,
+  });
+
+  assert.equal(report.ok, true);
+  assert.equal(report.status, "ok");
+  assert.deepEqual(report.reasons, []);
+  assert.deepEqual(report.lag.staleTickers, []);
+});
+
+test("reports warming up when hourly table has no rows yet and source has under 60 rows", async () => {
+  const report = await getWritePipelineHealth({
+    queryable: {
+      query: async <Row = unknown>() => ({
+        rows: [
+          {
+            ticker: "ES",
+            latest_source_time: "2026-03-17T18:20:00.000Z",
+            latest_source_row_count: 25,
+            latest_target_time: null,
+          },
+        ] as Row[],
+      }),
+    },
+    streamStatus: baseStreamStatus,
+    streamStats: baseStreamStats,
+  });
+
+  assert.equal(report.ok, true);
+  assert.equal(report.status, "warming_up");
+  assert.deepEqual(report.lag.warmingUpTickers, ["ES"]);
+});
+
+test("reports unhealthy when hourly lag exceeds threshold while market is open", async () => {
+  const report = await getWritePipelineHealth({
+    queryable: {
+      query: async <Row = unknown>() => ({
+        rows: [
+          {
+            ticker: "ES",
+            latest_source_time: "2026-03-17T18:53:00.000Z",
+            latest_source_row_count: 60,
+            latest_target_time: "2026-03-17T18:46:00.000Z",
+          },
+        ] as Row[],
+      }),
+    },
+    streamStatus: baseStreamStatus,
+    streamStats: baseStreamStats,
+    maxAllowedLagMinutes: 2,
+  });
+
+  assert.equal(report.ok, false);
+  assert.equal(report.status, "unhealthy");
+  assert.deepEqual(report.lag.staleTickers, ["ES"]);
+  assert.match(report.reasons[0] ?? "", /candles_1h_1m is stale/i);
+});
+
+test("does not mark market-closed tickers unhealthy for lag", async () => {
+  const report = await getWritePipelineHealth({
+    queryable: {
+      query: async <Row = unknown>() => ({
+        rows: [
+          {
+            ticker: "ES",
+            latest_source_time: "2026-03-17T18:53:00.000Z",
+            latest_source_row_count: 60,
+            latest_target_time: "2026-03-17T18:46:00.000Z",
+          },
+        ] as Row[],
+      }),
+    },
+    streamStatus: baseStreamStatus,
+    streamStats: {
+      ...baseStreamStats,
+      marketOpen: false,
+      marketOpenByTicker: {
+        ES: false,
+      },
+    },
+  });
+
+  assert.equal(report.ok, true);
+  assert.equal(report.status, "ok");
+  assert.equal(report.lag.tickers[0]?.status, "market_closed");
+});
+
+test("reports unhealthy when market is open but stream is disconnected", async () => {
+  const report = await getWritePipelineHealth({
+    queryable: {
+      query: async <Row = unknown>() => ({
+        rows: [
+          {
+            ticker: "ES",
+            latest_source_time: null,
+            latest_source_row_count: 0,
+            latest_target_time: null,
+          },
+        ] as Row[],
+      }),
+    },
+    streamStatus: {
+      ...baseStreamStatus,
+      connected: false,
+      authenticated: false,
+      streaming: false,
+    },
+    streamStats: baseStreamStats,
+    processUptimeMs: 180_000,
+  });
+
+  assert.equal(report.ok, false);
+  assert.equal(report.status, "unhealthy");
+  assert.match(report.reasons[0] ?? "", /stream is not fully ready/i);
+});
+
+test("treats early stream startup as warming up instead of unhealthy", async () => {
+  const report = await getWritePipelineHealth({
+    queryable: {
+      query: async <Row = unknown>() => ({
+        rows: [
+          {
+            ticker: "ES",
+            latest_source_time: null,
+            latest_source_row_count: 0,
+            latest_target_time: null,
+          },
+        ] as Row[],
+      }),
+    },
+    streamStatus: {
+      ...baseStreamStatus,
+      connected: false,
+      authenticated: false,
+      streaming: false,
+    },
+    streamStats: baseStreamStats,
+    processUptimeMs: 30_000,
+  });
+
+  assert.equal(report.ok, true);
+  assert.equal(report.status, "warming_up");
+  assert.equal(report.stream.startupGraceActive, true);
+});

--- a/apps-trading/write-node/src/lib/health/write-pipeline-health.ts
+++ b/apps-trading/write-node/src/lib/health/write-pipeline-health.ts
@@ -1,0 +1,249 @@
+interface QueryResultLike<Row> {
+  rows: Row[];
+}
+
+interface Queryable {
+  query: <Row = unknown>(text: string, values?: unknown[]) => Promise<QueryResultLike<Row>>;
+}
+
+export interface PipelineStreamStatus {
+  connected: boolean;
+  authenticated: boolean;
+  streaming: boolean;
+  reconnectAttempts: number;
+}
+
+export interface PipelineStreamStats {
+  marketOpen: boolean;
+  marketOpenByTicker: Record<string, boolean>;
+  messagesReceived?: number;
+  parseErrors?: number;
+  skippedMarketClosed?: number;
+}
+
+interface TickerLagRow {
+  ticker: string;
+  latest_source_time: Date | string | null;
+  latest_source_row_count: number | string;
+  latest_target_time: Date | string | null;
+}
+
+export interface TickerPipelineHealth {
+  ticker: string;
+  marketOpen: boolean;
+  status: "ok" | "warming_up" | "stale" | "market_closed" | "waiting_for_source";
+  latestSourceTime: string | null;
+  latestTargetTime: string | null;
+  latestSourceRowCount: number;
+  lagMinutes: number | null;
+}
+
+export interface WritePipelineHealthReport {
+  ok: boolean;
+  status: "ok" | "warming_up" | "unhealthy";
+  checkedAt: string;
+  reasons: string[];
+  stream: PipelineStreamStatus & {
+    marketOpen: boolean;
+    marketOpenByTicker: Record<string, boolean>;
+    messagesReceived: number | null;
+    parseErrors: number | null;
+    skippedMarketClosed: number | null;
+    startupGraceActive: boolean;
+    processUptimeSeconds: number;
+  };
+  lag: {
+    maxAllowedLagMinutes: number;
+    tickers: TickerPipelineHealth[];
+    staleTickers: string[];
+    warmingUpTickers: string[];
+  };
+}
+
+export interface WritePipelineHealthOptions {
+  queryable: Queryable;
+  streamStatus: PipelineStreamStatus;
+  streamStats: PipelineStreamStats;
+  now?: Date;
+  maxAllowedLagMinutes?: number;
+  processUptimeMs?: number;
+  startupGraceMs?: number;
+}
+
+const HEALTH_LAG_QUERY = `
+  WITH source_ranked AS (
+    SELECT
+      ticker,
+      time,
+      ROW_NUMBER() OVER (PARTITION BY ticker ORDER BY time DESC) AS rn
+    FROM candles_1m_1s
+    WHERE time = date_trunc('minute', time)
+  ),
+  source_summary AS (
+    SELECT
+      ticker,
+      MAX(time) FILTER (WHERE rn = 1) AS latest_source_time,
+      COUNT(*) FILTER (WHERE rn <= 60) AS latest_source_row_count
+    FROM source_ranked
+    GROUP BY ticker
+  ),
+  target_summary AS (
+    SELECT DISTINCT ON (ticker)
+      ticker,
+      time AS latest_target_time
+    FROM candles_1h_1m
+    ORDER BY ticker ASC, time DESC
+  )
+  SELECT
+    COALESCE(source_summary.ticker, target_summary.ticker) AS ticker,
+    source_summary.latest_source_time,
+    COALESCE(source_summary.latest_source_row_count, 0) AS latest_source_row_count,
+    target_summary.latest_target_time
+  FROM source_summary
+  FULL OUTER JOIN target_summary
+    ON target_summary.ticker = source_summary.ticker
+  ORDER BY ticker ASC
+`;
+
+function toIsoString(value: Date | string | null): string | null {
+  if (value === null) {
+    return null;
+  }
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function toMs(value: string | null): number | null {
+  if (value === null) {
+    return null;
+  }
+  return new Date(value).getTime();
+}
+
+function evaluateTickerHealth(
+  row: TickerLagRow | null,
+  marketOpen: boolean,
+  maxAllowedLagMinutes: number,
+): TickerPipelineHealth {
+  const latestSourceTime = toIsoString(row?.latest_source_time ?? null);
+  const latestTargetTime = toIsoString(row?.latest_target_time ?? null);
+  const latestSourceRowCount = row ? Number(row.latest_source_row_count) || 0 : 0;
+  const lagMinutes =
+    latestSourceTime && latestTargetTime
+      ? Math.max(0, Math.round((new Date(latestSourceTime).getTime() - new Date(latestTargetTime).getTime()) / 60_000))
+      : null;
+
+  if (!marketOpen) {
+    return {
+      ticker: row?.ticker ?? "__unknown__",
+      marketOpen,
+      status: "market_closed",
+      latestSourceTime,
+      latestTargetTime,
+      latestSourceRowCount,
+      lagMinutes,
+    };
+  }
+
+  if (latestSourceTime === null) {
+    return {
+      ticker: row?.ticker ?? "__unknown__",
+      marketOpen,
+      status: "waiting_for_source",
+      latestSourceTime,
+      latestTargetTime,
+      latestSourceRowCount,
+      lagMinutes,
+    };
+  }
+
+  if (latestTargetTime === null) {
+    return {
+      ticker: row?.ticker ?? "__unknown__",
+      marketOpen,
+      status: latestSourceRowCount < 60 ? "warming_up" : "stale",
+      latestSourceTime,
+      latestTargetTime,
+      latestSourceRowCount,
+      lagMinutes,
+    };
+  }
+
+  const sourceMs = toMs(latestSourceTime);
+  const targetMs = toMs(latestTargetTime);
+  const lagExceeded = sourceMs !== null && targetMs !== null && sourceMs - targetMs > maxAllowedLagMinutes * 60_000;
+
+  return {
+    ticker: row?.ticker ?? "__unknown__",
+    marketOpen,
+    status: lagExceeded ? "stale" : "ok",
+    latestSourceTime,
+    latestTargetTime,
+    latestSourceRowCount,
+    lagMinutes,
+  };
+}
+
+export async function getWritePipelineHealth({
+  queryable,
+  streamStatus,
+  streamStats,
+  now = new Date(),
+  maxAllowedLagMinutes = 2,
+  processUptimeMs = 0,
+  startupGraceMs = 120_000,
+}: WritePipelineHealthOptions): Promise<WritePipelineHealthReport> {
+  const result = await queryable.query<TickerLagRow>(HEALTH_LAG_QUERY);
+  const rowsByTicker = new Map(result.rows.map((row) => [row.ticker, row]));
+  const tickers = new Set<string>([...Object.keys(streamStats.marketOpenByTicker), ...rowsByTicker.keys()]);
+
+  const tickerHealth = [...tickers]
+    .sort((a, b) => a.localeCompare(b))
+    .map((ticker) => {
+      const base = evaluateTickerHealth(rowsByTicker.get(ticker) ?? { ticker, latest_source_time: null, latest_source_row_count: 0, latest_target_time: null }, streamStats.marketOpenByTicker[ticker] ?? false, maxAllowedLagMinutes);
+      return {
+        ...base,
+        ticker,
+      };
+    });
+
+  const staleTickers = tickerHealth.filter((ticker) => ticker.status === "stale").map((ticker) => ticker.ticker);
+  const warmingUpTickers = tickerHealth.filter((ticker) => ticker.status === "warming_up").map((ticker) => ticker.ticker);
+  const reasons: string[] = [];
+  const startupGraceActive = processUptimeMs < startupGraceMs;
+
+  if (streamStats.marketOpen && !startupGraceActive && (!streamStatus.connected || !streamStatus.authenticated || !streamStatus.streaming)) {
+    reasons.push(
+      `market is open but stream is not fully ready (connected=${streamStatus.connected}, authenticated=${streamStatus.authenticated}, streaming=${streamStatus.streaming})`,
+    );
+  }
+  if (staleTickers.length > 0) {
+    reasons.push(`candles_1h_1m is stale for: ${staleTickers.join(", ")}`);
+  }
+
+  const ok = reasons.length === 0;
+  const status: WritePipelineHealthReport["status"] =
+    ok && (warmingUpTickers.length > 0 || (streamStats.marketOpen && startupGraceActive)) ? "warming_up" : ok ? "ok" : "unhealthy";
+
+  return {
+    ok,
+    status,
+    checkedAt: now.toISOString(),
+    reasons,
+    stream: {
+      ...streamStatus,
+      marketOpen: streamStats.marketOpen,
+      marketOpenByTicker: streamStats.marketOpenByTicker,
+      messagesReceived: streamStats.messagesReceived ?? null,
+      parseErrors: streamStats.parseErrors ?? null,
+      skippedMarketClosed: streamStats.skippedMarketClosed ?? null,
+      startupGraceActive,
+      processUptimeSeconds: Math.round(processUptimeMs / 1000),
+    },
+    lag: {
+      maxAllowedLagMinutes,
+      tickers: tickerHealth,
+      staleTickers,
+      warmingUpTickers,
+    },
+  };
+}

--- a/apps-trading/write-node/src/lib/trade/canonical-candle.ts
+++ b/apps-trading/write-node/src/lib/trade/canonical-candle.ts
@@ -1,4 +1,4 @@
-import type { Candles1h1mRow, Candles1m1sRow } from "@lib/db-timescale/generated/typescript/db-types";
+import type { Candles1h1mRow, Candles1m1sRow } from "@lib/db-timescale/generated/typescript/db-types.ts";
 
 import type { CandleForDb, CandleState } from "./types.js";
 

--- a/apps-trading/write-node/src/lib/trade/canonical-candle.ts
+++ b/apps-trading/write-node/src/lib/trade/canonical-candle.ts
@@ -1,34 +1,40 @@
+import type { Candles1h1mRow, Candles1m1sRow } from "@lib/db-timescale/generated/typescript/db-types";
+
 import type { CandleForDb, CandleState } from "./types.js";
 
-export interface StoredCandleRow {
-  time: Date | string;
-  ticker: string;
-  symbol: string | null;
-  open: number | string;
-  high: number | string;
-  low: number | string;
-  close: number | string;
-  volume: number | string | null;
-  ask_volume: number | string | null;
-  bid_volume: number | string | null;
-  cvd_open: number | string | null;
-  cvd_high: number | string | null;
-  cvd_low: number | string | null;
-  cvd_close: number | string | null;
-  trades: number | string | null;
-  max_trade_size: number | string | null;
-  big_trades: number | string | null;
-  big_volume: number | string | null;
-  vd: number | string | null;
-  vd_ratio: number | string | null;
-  book_imbalance: number | string | null;
-  price_pct: number | string | null;
-  divergence: number | string | null;
-  sum_bid_depth: number | string | null;
-  sum_ask_depth: number | string | null;
-  sum_price_volume: number | string | null;
-  unknown_volume: number | string | null;
-}
+type StoredCandleCommonColumn =
+  | "time"
+  | "ticker"
+  | "symbol"
+  | "open"
+  | "high"
+  | "low"
+  | "close"
+  | "volume"
+  | "ask_volume"
+  | "bid_volume"
+  | "cvd_open"
+  | "cvd_high"
+  | "cvd_low"
+  | "cvd_close"
+  | "trades"
+  | "max_trade_size"
+  | "big_trades"
+  | "big_volume"
+  | "vd"
+  | "vd_ratio"
+  | "book_imbalance"
+  | "price_pct"
+  | "divergence"
+  | "sum_bid_depth"
+  | "sum_ask_depth"
+  | "sum_price_volume"
+  | "unknown_volume";
+
+type Stored1mCandleRow = Pick<Candles1m1sRow, StoredCandleCommonColumn>;
+type Stored1hCandleRow = Pick<Candles1h1mRow, StoredCandleCommonColumn>;
+
+export type StoredCandleRow = Stored1mCandleRow | Stored1hCandleRow;
 
 function toNumber(value: number | string | null | undefined): number {
   if (value === null || value === undefined) {

--- a/apps-trading/write-node/src/lib/trade/canonical-candle.ts
+++ b/apps-trading/write-node/src/lib/trade/canonical-candle.ts
@@ -31,8 +31,12 @@ type StoredCandleCommonColumn =
   | "sum_price_volume"
   | "unknown_volume";
 
-type Stored1mCandleRow = Pick<Candles1m1sRow, StoredCandleCommonColumn>;
-type Stored1hCandleRow = Pick<Candles1h1mRow, StoredCandleCommonColumn>;
+type Stored1mCandleRow = Omit<Pick<Candles1m1sRow, StoredCandleCommonColumn>, "time"> & {
+  time: Date | string;
+};
+type Stored1hCandleRow = Omit<Pick<Candles1h1mRow, StoredCandleCommonColumn>, "time"> & {
+  time: Date | string;
+};
 
 export type StoredCandleRow = Stored1mCandleRow | Stored1hCandleRow;
 

--- a/apps-trading/write-node/src/lib/trade/db-writer.test.ts
+++ b/apps-trading/write-node/src/lib/trade/db-writer.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { CandleForDb } from "./types.js";
+import { writeCandles } from "./db-writer.js";
+
+function makeCandleForDb(time: string): CandleForDb {
+  return {
+    key: `ES|${time}`,
+    ticker: "ES",
+    time,
+    candle: {
+      open: 6000,
+      high: 6002,
+      low: 5999,
+      close: 6001,
+      volume: 10,
+      askVolume: 6,
+      bidVolume: 4,
+      unknownSideVolume: 0,
+      sumBidDepth: 10,
+      sumAskDepth: 12,
+      sumSpread: 0,
+      sumMidPrice: 0,
+      sumPriceVolume: 60010,
+      maxTradeSize: 3,
+      largeTradeCount: 1,
+      largeTradeVolume: 3,
+      symbol: "ESH6",
+      tradeCount: 10,
+      currentCvd: 102,
+      metricsOHLC: {
+        cvd: {
+          open: 100,
+          high: 105,
+          low: 99,
+          close: 102,
+        },
+      },
+    },
+  };
+}
+
+test("writes explicit UTC second for candles_1m_1s", async () => {
+  const captured: { text: string; values: unknown[] } = { text: "", values: [] };
+
+  await writeCandles(
+    {
+      query: async (text, values) => {
+        captured.text = text;
+        captured.values = values;
+      },
+    },
+    "candles_1m_1s",
+    [makeCandleForDb("2026-03-10T14:59:59.000Z")],
+  );
+
+  assert.match(captured.text, /\bsecond\b/);
+  assert.match(captured.text, /second = EXCLUDED\.second/);
+  assert.equal(captured.values.at(-1), 59);
+});
+
+test("writes explicit UTC minute for candles_1h_1m", async () => {
+  const captured: { text: string; values: unknown[] } = { text: "", values: [] };
+
+  await writeCandles(
+    {
+      query: async (text, values) => {
+        captured.text = text;
+        captured.values = values;
+      },
+    },
+    "candles_1h_1m",
+    [makeCandleForDb("2026-03-10T14:59:00.000Z")],
+  );
+
+  assert.match(captured.text, /\bminute\b/);
+  assert.match(captured.text, /minute = EXCLUDED\.minute/);
+  assert.equal(captured.values.at(-1), 59);
+});

--- a/apps-trading/write-node/src/lib/trade/db-writer.ts
+++ b/apps-trading/write-node/src/lib/trade/db-writer.ts
@@ -1,17 +1,12 @@
 /**
  * Database Writer for Candles
  *
- * Shared logic for writing candles to the database.
- * Used across the canonical writer pipeline for both lower- and
- * higher-timeframe candle tables.
- *
- * Schema: 27 columns. Price and CVD have OHLC. Derived metrics (vd_ratio,
- * book_imbalance, price_pct, divergence) are calculated at write time from
- * the candle's raw aggregation state. Raw accumulators (sum_bid_depth,
- * sum_ask_depth, sum_price_volume, unknown_volume) are stored for correct
- * higher-timeframe aggregation. VWAP is derived at query time from
- * sum_price_volume / volume — not stored per-row.
+ * Shared logic for writing canonical candle rows to TimescaleDB. Each target
+ * table carries the same rolling metrics plus an explicit UTC sample offset:
+ * `second` for `candles_1m_1s` and `minute` for `candles_1h_1m`.
  */
+
+import type { Candles1h1mRow, Candles1m1sRow } from "@lib/db-timescale/generated/typescript/db-types";
 
 import type { CandleForDb, CandleState } from "./types.js";
 import { calculateVd, calculateVdRatio } from "../metrics/index.js";
@@ -19,169 +14,106 @@ import { calculateBookImbalance } from "../metrics/book-imbalance.js";
 import { calculatePricePct } from "../metrics/price.js";
 import { calculateDivergence } from "../metrics/absorption.js";
 
-/** Number of columns in the candles INSERT statement */
-const COLUMNS_PER_ROW = 27;
+type QueryValue = string | number | Date | null;
+type CandleTableName = "candles_1m_1s" | "candles_1h_1m";
+
+const CANDLES_1M_1S_COLUMNS = [
+  "time",
+  "ticker",
+  "symbol",
+  "open",
+  "high",
+  "low",
+  "close",
+  "volume",
+  "ask_volume",
+  "bid_volume",
+  "cvd_open",
+  "cvd_high",
+  "cvd_low",
+  "cvd_close",
+  "vd",
+  "vd_ratio",
+  "book_imbalance",
+  "price_pct",
+  "divergence",
+  "trades",
+  "max_trade_size",
+  "big_trades",
+  "big_volume",
+  "sum_bid_depth",
+  "sum_ask_depth",
+  "sum_price_volume",
+  "unknown_volume",
+  "second",
+] as const satisfies readonly (keyof Candles1m1sRow)[];
+
+const CANDLES_1H_1M_COLUMNS = [
+  "time",
+  "ticker",
+  "symbol",
+  "open",
+  "high",
+  "low",
+  "close",
+  "volume",
+  "ask_volume",
+  "bid_volume",
+  "cvd_open",
+  "cvd_high",
+  "cvd_low",
+  "cvd_close",
+  "vd",
+  "vd_ratio",
+  "book_imbalance",
+  "price_pct",
+  "divergence",
+  "trades",
+  "max_trade_size",
+  "big_trades",
+  "big_volume",
+  "sum_bid_depth",
+  "sum_ask_depth",
+  "sum_price_volume",
+  "unknown_volume",
+  "minute",
+] as const satisfies readonly (keyof Candles1h1mRow)[];
+
+const SUPPORTED_CANDLE_TABLES = new Set<CandleTableName>(["candles_1m_1s", "candles_1h_1m"]);
 
 interface Queryable {
-  query: (text: string, values: (string | number | null)[]) => Promise<unknown>;
+  query: (text: string, values: QueryValue[]) => Promise<unknown>;
 }
 
-/**
- * Build placeholder string for parameterized query
- * @param offset - Starting parameter number (0-based index * COLUMNS_PER_ROW)
- * @param count - Number of columns
- */
-function buildPlaceholder(offset: number, count: number): string {
-  const parts: string[] = [];
-  for (let i = 1; i <= count; i++) {
-    parts.push(`$${offset + i}`);
-  }
-  return `(${parts.join(", ")})`;
+interface CvdRowValues {
+  cvd_open: number | null;
+  cvd_high: number | null;
+  cvd_low: number | null;
+  cvd_close: number | null;
 }
 
-/**
- * Build the INSERT query for candles
- * @param tableName - Target table name (e.g., "candles_1m_1s")
- * @param placeholders - Array of placeholder strings from buildPlaceholder
- */
-function buildCandleInsertQuery(tableName: string, placeholders: string[]): string {
-  return `
-    INSERT INTO ${tableName} (
-      time, ticker, symbol,
-      open, high, low, close, volume,
-      ask_volume, bid_volume,
-      cvd_open, cvd_high, cvd_low, cvd_close,
-      vd, vd_ratio, book_imbalance, price_pct, divergence,
-      trades, max_trade_size, big_trades, big_volume,
-      sum_bid_depth, sum_ask_depth, sum_price_volume, unknown_volume
-    )
-    VALUES ${placeholders.join(", ")}
-    ON CONFLICT (ticker, time) DO UPDATE SET
-      symbol = EXCLUDED.symbol,
-      open = EXCLUDED.open,
-      high = EXCLUDED.high,
-      low = EXCLUDED.low,
-      close = EXCLUDED.close,
-      volume = EXCLUDED.volume,
-      ask_volume = EXCLUDED.ask_volume,
-      bid_volume = EXCLUDED.bid_volume,
-      cvd_open = EXCLUDED.cvd_open,
-      cvd_high = EXCLUDED.cvd_high,
-      cvd_low = EXCLUDED.cvd_low,
-      cvd_close = EXCLUDED.cvd_close,
-      vd = EXCLUDED.vd,
-      vd_ratio = EXCLUDED.vd_ratio,
-      book_imbalance = EXCLUDED.book_imbalance,
-      price_pct = EXCLUDED.price_pct,
-      divergence = EXCLUDED.divergence,
-      trades = EXCLUDED.trades,
-      max_trade_size = EXCLUDED.max_trade_size,
-      big_trades = EXCLUDED.big_trades,
-      big_volume = EXCLUDED.big_volume,
-      sum_bid_depth = EXCLUDED.sum_bid_depth,
-      sum_ask_depth = EXCLUDED.sum_ask_depth,
-      sum_price_volume = EXCLUDED.sum_price_volume,
-      unknown_volume = EXCLUDED.unknown_volume
-  `;
-}
-
-/**
- * Calculate derived metrics from candle state.
- * Used by both fallback and OHLC row builders.
- */
-function calculateDerivedMetrics(candle: CandleState) {
-  const vd = candle.askVolume - candle.bidVolume;
-  const vdRatio = calculateVdRatio(candle.askVolume, candle.bidVolume);
-  const bookImbalance = calculateBookImbalance(candle.sumBidDepth, candle.sumAskDepth);
-  const pricePct = calculatePricePct(candle.open, candle.close);
-  const divergence = calculateDivergence(pricePct, vdRatio);
-  return { vd, vdRatio, bookImbalance, pricePct, divergence };
-}
-
-/**
- * Build values array for a single candle row (fallback when no metricsOHLC)
- * Used when a candle doesn't have OHLC tracking (shouldn't normally happen)
- */
-function buildFallbackRowValues(time: string, ticker: string, candle: CandleState, cvd: number): (string | number | null)[] {
-  const { vd, vdRatio, bookImbalance, pricePct, divergence } = calculateDerivedMetrics(candle);
-
-  return [
-    time,
-    ticker,
-    candle.symbol,
-    candle.open,
-    candle.high,
-    candle.low,
-    candle.close,
-    candle.volume,
-    // Volume breakdown
-    candle.askVolume,
-    candle.bidVolume,
-    // CVD OHLC (all same since no tracking)
-    cvd,
-    cvd,
-    cvd,
-    cvd,
-    // Volume Delta & derived metrics
-    vd,
-    vdRatio,
-    bookImbalance,
-    pricePct,
-    divergence,
-    // Activity
-    candle.tradeCount,
-    candle.maxTradeSize,
-    candle.largeTradeCount,
-    candle.largeTradeVolume,
-    // Raw accumulators for higher-timeframe aggregation
-    candle.sumBidDepth,
-    candle.sumAskDepth,
-    candle.sumPriceVolume,
-    candle.unknownSideVolume,
-  ];
-}
-
-/**
- * Build values array for a single candle row with metricsOHLC
- */
-function buildOhlcRowValues(time: string, ticker: string, candle: CandleState): (string | number | null)[] {
-  const m = candle.metricsOHLC!;
-  const { vd, vdRatio, bookImbalance, pricePct, divergence } = calculateDerivedMetrics(candle);
-
-  return [
-    time,
-    ticker,
-    candle.symbol,
-    candle.open,
-    candle.high,
-    candle.low,
-    candle.close,
-    candle.volume,
-    // Volume breakdown
-    candle.askVolume,
-    candle.bidVolume,
-    // CVD OHLC (tracked throughout the candle)
-    m.cvd.open,
-    m.cvd.high,
-    m.cvd.low,
-    m.cvd.close,
-    // Volume Delta & derived metrics
-    vd,
-    vdRatio,
-    bookImbalance,
-    pricePct,
-    divergence,
-    // Activity
-    candle.tradeCount,
-    candle.maxTradeSize,
-    candle.largeTradeCount,
-    candle.largeTradeVolume,
-    // Raw accumulators for higher-timeframe aggregation
-    candle.sumBidDepth,
-    candle.sumAskDepth,
-    candle.sumPriceVolume,
-    candle.unknownSideVolume,
-  ];
+interface SharedRowValues extends CvdRowValues {
+  symbol: string | null;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+  ask_volume: number;
+  bid_volume: number;
+  vd: number;
+  vd_ratio: number | null;
+  book_imbalance: number | null;
+  price_pct: number | null;
+  divergence: number | null;
+  trades: number;
+  max_trade_size: number;
+  big_trades: number;
+  big_volume: number;
+  sum_bid_depth: number;
+  sum_ask_depth: number;
+  sum_price_volume: number;
+  unknown_volume: number;
 }
 
 /**
@@ -194,42 +126,198 @@ export interface CvdContext {
   updateCvd?: (ticker: string, newCvd: number) => void;
 }
 
+function assertSupportedCandleTable(tableName: string): asserts tableName is CandleTableName {
+  if (SUPPORTED_CANDLE_TABLES.has(tableName as CandleTableName)) {
+    return;
+  }
+
+  throw new Error(`Unsupported candle table: ${tableName}`);
+}
+
 /**
- * Build INSERT parameters for a batch of candles
- *
- * @param candles - Array of candles to insert
- * @param cvdContext - Context for CVD calculations
- * @returns Object with values array and placeholders array
+ * Build placeholder string for parameterized query.
+ */
+function buildPlaceholder(offset: number, count: number): string {
+  const parts: string[] = [];
+  for (let i = 1; i <= count; i++) {
+    parts.push(`$${offset + i}`);
+  }
+  return `(${parts.join(", ")})`;
+}
+
+function getColumnsForTable(tableName: CandleTableName): readonly string[] {
+  switch (tableName) {
+    case "candles_1m_1s":
+      return CANDLES_1M_1S_COLUMNS;
+    case "candles_1h_1m":
+      return CANDLES_1H_1M_COLUMNS;
+  }
+}
+
+function getColumnValues<Row extends object>(
+  row: Row,
+  columns: readonly (keyof Row & string)[],
+): QueryValue[] {
+  return columns.map((column) => row[column] as QueryValue);
+}
+
+/**
+ * Build the INSERT query for candles.
+ */
+function buildCandleInsertQuery(tableName: CandleTableName, placeholders: string[]): string {
+  const columns = getColumnsForTable(tableName);
+  const updateColumns = columns.filter((column) => column !== "time" && column !== "ticker");
+
+  return `
+    INSERT INTO ${tableName} (
+      ${columns.join(", ")}
+    )
+    VALUES ${placeholders.join(", ")}
+    ON CONFLICT (ticker, time) DO UPDATE SET
+      ${updateColumns.map((column) => `${column} = EXCLUDED.${column}`).join(",\n      ")}
+  `;
+}
+
+/**
+ * Calculate derived metrics from candle state.
+ */
+function calculateDerivedMetrics(candle: CandleState) {
+  const vd = candle.askVolume - candle.bidVolume;
+  const vdRatio = calculateVdRatio(candle.askVolume, candle.bidVolume);
+  const bookImbalance = calculateBookImbalance(candle.sumBidDepth, candle.sumAskDepth);
+  const pricePct = calculatePricePct(candle.open, candle.close);
+  const divergence = calculateDivergence(pricePct, vdRatio);
+  return { vd, vdRatio, bookImbalance, pricePct, divergence };
+}
+
+function toTimestamp(time: string): Date {
+  const timestamp = new Date(time);
+  if (Number.isNaN(timestamp.getTime())) {
+    throw new Error(`Invalid candle timestamp: ${time}`);
+  }
+  return timestamp;
+}
+
+function buildSharedRowValues(candle: CandleState, cvdValues: CvdRowValues): SharedRowValues {
+  const { vd, vdRatio, bookImbalance, pricePct, divergence } = calculateDerivedMetrics(candle);
+
+  return {
+    symbol: candle.symbol,
+    open: candle.open,
+    high: candle.high,
+    low: candle.low,
+    close: candle.close,
+    volume: candle.volume,
+    ask_volume: candle.askVolume,
+    bid_volume: candle.bidVolume,
+    ...cvdValues,
+    vd,
+    vd_ratio: vdRatio,
+    book_imbalance: bookImbalance,
+    price_pct: pricePct,
+    divergence,
+    trades: candle.tradeCount,
+    max_trade_size: candle.maxTradeSize,
+    big_trades: candle.largeTradeCount,
+    big_volume: candle.largeTradeVolume,
+    sum_bid_depth: candle.sumBidDepth,
+    sum_ask_depth: candle.sumAskDepth,
+    sum_price_volume: candle.sumPriceVolume,
+    unknown_volume: candle.unknownSideVolume,
+  };
+}
+
+function buildCandles1m1sRow(time: string, ticker: string, candle: CandleState, cvdValues: CvdRowValues): Candles1m1sRow {
+  const timestamp = toTimestamp(time);
+
+  return {
+    time: timestamp,
+    ticker,
+    ...buildSharedRowValues(candle, cvdValues),
+    second: timestamp.getUTCSeconds(),
+  };
+}
+
+function buildCandles1h1mRow(time: string, ticker: string, candle: CandleState, cvdValues: CvdRowValues): Candles1h1mRow {
+  const timestamp = toTimestamp(time);
+
+  return {
+    time: timestamp,
+    ticker,
+    ...buildSharedRowValues(candle, cvdValues),
+    minute: timestamp.getUTCMinutes(),
+  };
+}
+
+function buildRowForTable(
+  tableName: CandleTableName,
+  time: string,
+  ticker: string,
+  candle: CandleState,
+  cvdValues: CvdRowValues,
+): Candles1m1sRow | Candles1h1mRow {
+  switch (tableName) {
+    case "candles_1m_1s":
+      return buildCandles1m1sRow(time, ticker, candle, cvdValues);
+    case "candles_1h_1m":
+      return buildCandles1h1mRow(time, ticker, candle, cvdValues);
+  }
+}
+
+function buildRowValuesForTable(tableName: CandleTableName, row: Candles1m1sRow | Candles1h1mRow): QueryValue[] {
+  switch (tableName) {
+    case "candles_1m_1s":
+      return getColumnValues(row as Candles1m1sRow, CANDLES_1M_1S_COLUMNS);
+    case "candles_1h_1m":
+      return getColumnValues(row as Candles1h1mRow, CANDLES_1H_1M_COLUMNS);
+  }
+}
+
+/**
+ * Build INSERT parameters for a batch of candles.
  */
 function buildCandleInsertParams(
+  tableName: CandleTableName,
   candles: CandleForDb[],
   cvdContext: CvdContext,
 ): {
-  values: (string | number | null)[];
+  values: QueryValue[];
   placeholders: string[];
 } {
-  const values: (string | number | null)[] = [];
+  const values: QueryValue[] = [];
   const placeholders: string[] = [];
+  const columnsPerRow = getColumnsForTable(tableName).length;
 
   candles.forEach(({ ticker, time, candle }, i) => {
-    const m = candle.metricsOHLC;
-    const offset = i * COLUMNS_PER_ROW;
+    const metrics = candle.metricsOHLC;
+    const offset = i * columnsPerRow;
 
-    placeholders.push(buildPlaceholder(offset, COLUMNS_PER_ROW));
+    placeholders.push(buildPlaceholder(offset, columnsPerRow));
 
-    if (!m) {
-      // Fallback: no metricsOHLC, calculate CVD from base
+    if (!metrics) {
       const baseCvd = cvdContext.getBaseCvd(ticker);
       const vd = calculateVd(candle.askVolume, candle.bidVolume);
       const cvd = baseCvd + vd;
       cvdContext.updateCvd?.(ticker, cvd);
 
-      values.push(...buildFallbackRowValues(time, ticker, candle, cvd));
-    } else {
-      // Has metricsOHLC - use it
-      cvdContext.updateCvd?.(ticker, m.cvd.close);
-      values.push(...buildOhlcRowValues(time, ticker, candle));
+      const row = buildRowForTable(tableName, time, ticker, candle, {
+        cvd_open: cvd,
+        cvd_high: cvd,
+        cvd_low: cvd,
+        cvd_close: cvd,
+      });
+      values.push(...buildRowValuesForTable(tableName, row));
+      return;
     }
+
+    cvdContext.updateCvd?.(ticker, metrics.cvd.close);
+    const row = buildRowForTable(tableName, time, ticker, candle, {
+      cvd_open: metrics.cvd.open,
+      cvd_high: metrics.cvd.high,
+      cvd_low: metrics.cvd.low,
+      cvd_close: metrics.cvd.close,
+    });
+    values.push(...buildRowValuesForTable(tableName, row));
   });
 
   return { values, placeholders };
@@ -243,6 +331,8 @@ export async function writeCandles(queryable: Queryable, tableName: string, cand
     return;
   }
 
+  assertSupportedCandleTable(tableName);
+
   const sorted = [...candles].sort((a, b) => {
     if (a.ticker !== b.ticker) {
       return a.ticker.localeCompare(b.ticker);
@@ -255,7 +345,7 @@ export async function writeCandles(queryable: Queryable, tableName: string, cand
     updateCvd: () => {},
   };
 
-  const { values, placeholders } = buildCandleInsertParams(sorted, cvdContext);
+  const { values, placeholders } = buildCandleInsertParams(tableName, sorted, cvdContext);
   const query = buildCandleInsertQuery(tableName, placeholders);
   await queryable.query(query, values);
 }

--- a/apps-trading/write-node/src/lib/trade/db-writer.ts
+++ b/apps-trading/write-node/src/lib/trade/db-writer.ts
@@ -6,7 +6,7 @@
  * `second` for `candles_1m_1s` and `minute` for `candles_1h_1m`.
  */
 
-import type { Candles1h1mRow, Candles1m1sRow } from "@lib/db-timescale/generated/typescript/db-types";
+import type { Candles1h1mRow, Candles1m1sRow } from "@lib/db-timescale/generated/typescript/db-types.ts";
 
 import type { CandleForDb, CandleState } from "./types.js";
 import { calculateVd, calculateVdRatio } from "../metrics/index.js";

--- a/apps-trading/write-node/src/stream/AGENTS.md
+++ b/apps-trading/write-node/src/stream/AGENTS.md
@@ -17,6 +17,7 @@ downstream feature-engineering or ML-specific logic.
   - Converts trade messages (action="T") into `TbboRecord` objects
   - Skips spread contracts (symbols containing "-") and gates trades by the configured session calendar using the trade event timestamp
   - Passes each valid trade to the aggregator
+  - exposes lag-aware `/api/v1/health` inputs via stream readiness/status helpers
 
 - **`tbbo-1m-aggregator.ts`** is the live wrapper around the shared rolling-window engine
   - rejects late trades

--- a/apps-trading/write-node/src/stream/AGENTS.md
+++ b/apps-trading/write-node/src/stream/AGENTS.md
@@ -39,6 +39,7 @@ downstream feature-engineering or ML-specific logic.
 - **`candles-1h-1m-aggregator.ts`** derives rolling hourly rows from canonical
   minute-boundary rows
   - hydrates from recent `candles_1m_1s` minute-boundary rows on startup
+  - reconciles missed minute-boundary source rows from `candles_1m_1s` during runtime
   - accepts only canonical lower-timeframe rows, never raw trades
   - writes `candles_1h_1m`
 

--- a/apps-trading/write-node/src/stream/AGENTS.md
+++ b/apps-trading/write-node/src/stream/AGENTS.md
@@ -18,6 +18,7 @@ downstream feature-engineering or ML-specific logic.
   - Skips spread contracts (symbols containing "-") and gates trades by the configured session calendar using the trade event timestamp
   - Passes each valid trade to the aggregator
   - exposes lag-aware `/api/v1/health` inputs via stream readiness/status helpers
+  - can trigger automatic remediation restart when hourly lag stays unhealthy long enough
 
 - **`tbbo-1m-aggregator.ts`** is the live wrapper around the shared rolling-window engine
   - rejects late trades

--- a/apps-trading/write-node/src/stream/candles-1h-1m-aggregator.test.ts
+++ b/apps-trading/write-node/src/stream/candles-1h-1m-aggregator.test.ts
@@ -22,6 +22,14 @@ function isReconciliationQuery(text: string): boolean {
   return text.includes("WITH latest_target(ticker, latest_target_time)");
 }
 
+function isLatestSourceQuery(text: string): boolean {
+  return text.includes("latest_source_time") && text.includes("FROM candles_1m_1s");
+}
+
+function isSourceRangeQuery(text: string): boolean {
+  return text.includes("WITH source_range(ticker, start_exclusive_time, end_inclusive_time)");
+}
+
 function minuteIso(offset: number): string {
   return new Date(BASE_TIME_MS + offset * 60_000).toISOString();
 }
@@ -88,6 +96,16 @@ test("requeues hourly candles after transient write failure", async () => {
           return { rows: [] as Row[] };
         }
 
+        if (isLatestSourceQuery(text)) {
+          return {
+            rows: [{ ticker: "ES", latest_source_time: minuteIso(60) }] as Row[],
+          };
+        }
+
+        if (isSourceRangeQuery(text)) {
+          return { rows: [] as Row[] };
+        }
+
         throw new Error(`Unexpected query: ${text}`);
       },
     },
@@ -102,7 +120,7 @@ test("requeues hourly candles after transient write failure", async () => {
   });
 
   await aggregator.initialize();
-  assert.equal(aggregator.addBaseCandles([makeBaseCandle(60)]), 1);
+  assert.equal(await aggregator.addBaseCandles([makeBaseCandle(60)]), 1);
 
   await aggregator.flushCompleted();
   assert.deepEqual(writtenTimes, []);
@@ -138,6 +156,16 @@ test("retries startup hydration and replays buffered base candles", async () => 
           return { rows: [] as Row[] };
         }
 
+        if (isLatestSourceQuery(text)) {
+          return {
+            rows: [{ ticker: "ES", latest_source_time: minuteIso(60) }] as Row[],
+          };
+        }
+
+        if (isSourceRangeQuery(text)) {
+          return { rows: [] as Row[] };
+        }
+
         throw new Error(`Unexpected query: ${text}`);
       },
     },
@@ -147,7 +175,7 @@ test("retries startup hydration and replays buffered base candles", async () => 
   });
 
   await aggregator.initialize();
-  assert.equal(aggregator.addBaseCandles([makeBaseCandle(60)]), 1);
+  assert.equal(await aggregator.addBaseCandles([makeBaseCandle(60)]), 1);
 
   await aggregator.flushCompleted();
   assert.equal(hydrationQueries, 2);
@@ -196,4 +224,96 @@ test("reconciles missing hourly rows from canonical 1m source on startup", async
 
   assert.deepEqual(writtenTimes, [minuteIso(60)]);
   assert.equal(aggregator.getCandlesWritten(), 1);
+});
+
+test("replays missing source rows before ingesting newer live handoff rows", async () => {
+  const seedRows = Array.from({ length: 60 }, (_, i) => makeStoredRow(i));
+  const catchupRows = [makeStoredRow(60), makeStoredRow(61)];
+  const writtenTimes: string[] = [];
+  let sourceRangeQueries = 0;
+
+  const aggregator = new Candles1h1mAggregator({
+    queryable: {
+      query: async <Row = unknown>(text: string, _values?: unknown[]) => {
+        if (isLatestTargetQuery(text)) {
+          return { rows: [] as Row[] };
+        }
+
+        if (isHydrationQuery(text)) {
+          return { rows: seedRows as Row[] };
+        }
+
+        if (isReconciliationQuery(text)) {
+          return { rows: [] as Row[] };
+        }
+
+        if (isSourceRangeQuery(text)) {
+          sourceRangeQueries++;
+          return { rows: catchupRows as Row[] };
+        }
+
+        if (isLatestSourceQuery(text)) {
+          return {
+            rows: [{ ticker: "ES", latest_source_time: minuteIso(62) }] as Row[],
+          };
+        }
+
+        throw new Error(`Unexpected query: ${text}`);
+      },
+    },
+    writeCandlesFn: async (_queryable, _tableName, candles) => {
+      writtenTimes.push(...candles.map((candle) => candle.time));
+    },
+  });
+
+  await aggregator.initialize();
+  assert.equal(await aggregator.addBaseCandles([makeBaseCandle(62)]), 1);
+  await aggregator.flushCompleted();
+
+  assert.equal(sourceRangeQueries, 1);
+  assert.deepEqual(writtenTimes, [minuteIso(60), minuteIso(61), minuteIso(62)]);
+});
+
+test("runtime reconciliation catches up missed source rows without a fresh handoff", async () => {
+  const seedRows = Array.from({ length: 60 }, (_, i) => makeStoredRow(i));
+  const catchupRows = [makeStoredRow(60), makeStoredRow(61), makeStoredRow(62)];
+  const writtenTimes: string[] = [];
+
+  const aggregator = new Candles1h1mAggregator({
+    queryable: {
+      query: async <Row = unknown>(text: string, _values?: unknown[]) => {
+        if (isLatestTargetQuery(text)) {
+          return { rows: [] as Row[] };
+        }
+
+        if (isHydrationQuery(text)) {
+          return { rows: seedRows as Row[] };
+        }
+
+        if (isReconciliationQuery(text)) {
+          return { rows: [] as Row[] };
+        }
+
+        if (isLatestSourceQuery(text)) {
+          return {
+            rows: [{ ticker: "ES", latest_source_time: minuteIso(62) }] as Row[],
+          };
+        }
+
+        if (isSourceRangeQuery(text)) {
+          return { rows: catchupRows as Row[] };
+        }
+
+        throw new Error(`Unexpected query: ${text}`);
+      },
+    },
+    writeCandlesFn: async (_queryable, _tableName, candles) => {
+      writtenTimes.push(...candles.map((candle) => candle.time));
+    },
+  });
+
+  await aggregator.initialize();
+  await aggregator.flushCompleted();
+
+  assert.deepEqual(writtenTimes, [minuteIso(60), minuteIso(61), minuteIso(62)]);
 });

--- a/apps-trading/write-node/src/stream/candles-1h-1m-aggregator.ts
+++ b/apps-trading/write-node/src/stream/candles-1h-1m-aggregator.ts
@@ -107,9 +107,9 @@ interface LatestTargetRow {
   latest_target_time: Date | string;
 }
 
-interface ReconciliationSourceRow extends StoredCandleRow {
+type ReconciliationSourceRow = StoredCandleRow & {
   latest_target_time: Date | string;
-}
+};
 
 interface ReconciliationCursor {
   ticker: string;

--- a/apps-trading/write-node/src/stream/candles-1h-1m-aggregator.ts
+++ b/apps-trading/write-node/src/stream/candles-1h-1m-aggregator.ts
@@ -8,6 +8,7 @@ const HYDRATION_WINDOW_ROWS = 60;
 const WINDOW_MINUTES = 60;
 const WRITE_BATCH_SIZE = 500;
 const HYDRATION_RETRY_LOG_INTERVAL_MS = 30_000;
+const RUNTIME_RECONCILIATION_INTERVAL_MS = 10_000;
 const RECONCILIATION_PAGE_SIZE = 5_000;
 const RECONCILIATION_FLUSH_THRESHOLD = 10_000;
 
@@ -94,6 +95,15 @@ const LATEST_TARGET_TIMES_QUERY = `
   ORDER BY ticker ASC, time DESC
 `;
 
+const LATEST_SOURCE_TIMES_QUERY = `
+  SELECT DISTINCT ON (ticker)
+    ticker,
+    time AS latest_source_time
+  FROM ${SOURCE_TABLE}
+  WHERE time = date_trunc('minute', time)
+  ORDER BY ticker ASC, time DESC
+`;
+
 interface QueryResultLike<Row> {
   rows: Row[];
 }
@@ -107,9 +117,20 @@ interface LatestTargetRow {
   latest_target_time: Date | string;
 }
 
+interface LatestSourceRow {
+  ticker: string;
+  latest_source_time: Date | string;
+}
+
 type ReconciliationSourceRow = StoredCandleRow & {
   latest_target_time: Date | string;
 };
+
+interface SourceCatchupRange {
+  ticker: string;
+  start_exclusive_time: string;
+  end_inclusive_time: string;
+}
 
 interface ReconciliationCursor {
   ticker: string;
@@ -129,17 +150,16 @@ interface Candles1h1mAggregatorOptions {
 export class Candles1h1mAggregator {
   private readonly queryable: Queryable;
   private readonly writeCandlesFn: typeof writeCandles;
-  private readonly rollingWindow = new RollingCandleWindow({
-    windowSize: WINDOW_MINUTES,
-    expectedIntervalMs: 60_000,
-    label: "1h@1m",
-  });
+  private rollingWindow = this.createRollingWindow();
 
   private initialized = false;
   private candlesWritten = 0;
   private bufferedBaseCandles: CandleForDb[] = [];
   private hydrationPromise: Promise<boolean> | null = null;
+  private runtimeReconciliationPromise: Promise<number> | null = null;
   private lastHydrationBlockedLogTime = 0;
+  private lastRuntimeReconciliationTime = 0;
+  private readonly lastSourceTimeByTicker = new Map<string, string>();
 
   constructor(options: Candles1h1mAggregatorOptions = {}) {
     this.queryable = options.queryable ?? pool;
@@ -150,7 +170,7 @@ export class Candles1h1mAggregator {
     await this.ensureInitialized();
   }
 
-  addBaseCandles(candles: CandleForDb[]): number {
+  async addBaseCandles(candles: CandleForDb[]): Promise<number> {
     const minuteBoundaryCandles = candles.filter((candle) => isMinuteBoundary(candle.time));
     if (minuteBoundaryCandles.length === 0) {
       return 0;
@@ -161,7 +181,10 @@ export class Candles1h1mAggregator {
       return minuteBoundaryCandles.length;
     }
 
-    return this.rollingWindow.addCandles(minuteBoundaryCandles);
+    await this.catchUpBeforeIncomingCandles(minuteBoundaryCandles);
+    const accepted = this.rollingWindow.addCandles(minuteBoundaryCandles);
+    this.recordSourceCandles(minuteBoundaryCandles);
+    return accepted;
   }
 
   async flushCompleted(): Promise<void> {
@@ -171,6 +194,7 @@ export class Candles1h1mAggregator {
       return;
     }
 
+    await this.maybeReconcileRuntimeLag();
     await this.flushPendingCandles();
   }
 
@@ -180,6 +204,14 @@ export class Candles1h1mAggregator {
 
   getCandlesWritten(): number {
     return this.candlesWritten;
+  }
+
+  private createRollingWindow(): RollingCandleWindow {
+    return new RollingCandleWindow({
+      windowSize: WINDOW_MINUTES,
+      expectedIntervalMs: 60_000,
+      label: "1h@1m",
+    });
   }
 
   private async flushPendingCandles(): Promise<void> {
@@ -218,6 +250,129 @@ export class Candles1h1mAggregator {
     }
   }
 
+  private recordSourceCandles(candles: CandleForDb[]): void {
+    for (const candle of candles) {
+      this.recordSourceTime(candle.ticker, candle.time);
+    }
+  }
+
+  private recordSourceRows(rows: StoredCandleRow[]): void {
+    for (const row of rows) {
+      const time = row.time instanceof Date ? row.time.toISOString() : new Date(row.time).toISOString();
+      this.recordSourceTime(row.ticker, time);
+    }
+  }
+
+  private recordSourceTime(ticker: string, time: string): void {
+    const current = this.lastSourceTimeByTicker.get(ticker);
+    if (!current || time > current) {
+      this.lastSourceTimeByTicker.set(ticker, time);
+    }
+  }
+
+  private async catchUpBeforeIncomingCandles(candles: CandleForDb[]): Promise<void> {
+    const ranges = this.buildCatchupRangesBeforeIncomingCandles(candles);
+    if (ranges.length === 0) {
+      return;
+    }
+
+    const rows = await this.loadSourceRowsInRanges(ranges);
+    if (rows.length === 0) {
+      return;
+    }
+
+    const sourceCandles = rows.map((row) => candleForDbFromStoredRow(row, { requireCompleteCvd: true }));
+    this.rollingWindow.addCandles(sourceCandles);
+    this.recordSourceRows(rows);
+    console.log(`🔁 Replayed ${sourceCandles.length} canonical 1m row(s) ahead of live handoff into ${TARGET_TABLE}`);
+  }
+
+  private buildCatchupRangesBeforeIncomingCandles(candles: CandleForDb[]): SourceCatchupRange[] {
+    const earliestTimeByTicker = new Map<string, string>();
+    for (const candle of candles) {
+      const current = earliestTimeByTicker.get(candle.ticker);
+      if (!current || candle.time < current) {
+        earliestTimeByTicker.set(candle.ticker, candle.time);
+      }
+    }
+
+    const ranges: SourceCatchupRange[] = [];
+    for (const [ticker, earliestIncomingTime] of earliestTimeByTicker) {
+      const lastSourceTime = this.lastSourceTimeByTicker.get(ticker);
+      if (!lastSourceTime) {
+        continue;
+      }
+
+      const earliestIncomingMs = new Date(earliestIncomingTime).getTime();
+      const endInclusiveMs = earliestIncomingMs - 60_000;
+      if (endInclusiveMs <= new Date(lastSourceTime).getTime()) {
+        continue;
+      }
+
+      ranges.push({
+        ticker,
+        start_exclusive_time: lastSourceTime,
+        end_inclusive_time: new Date(endInclusiveMs).toISOString(),
+      });
+    }
+
+    return ranges;
+  }
+
+  private async maybeReconcileRuntimeLag(): Promise<void> {
+    const now = Date.now();
+    if (now - this.lastRuntimeReconciliationTime < RUNTIME_RECONCILIATION_INTERVAL_MS) {
+      return;
+    }
+
+    if (this.runtimeReconciliationPromise) {
+      await this.runtimeReconciliationPromise;
+      return;
+    }
+
+    this.lastRuntimeReconciliationTime = now;
+    this.runtimeReconciliationPromise = this.reconcileRuntimeLag().finally(() => {
+      this.runtimeReconciliationPromise = null;
+    });
+    await this.runtimeReconciliationPromise;
+  }
+
+  private async reconcileRuntimeLag(): Promise<number> {
+    const latestSourceTimes = await this.loadLatestSourceTimes();
+    const ranges: SourceCatchupRange[] = [];
+
+    for (const row of latestSourceTimes) {
+      const latestSourceTime = row.latest_source_time instanceof Date ? row.latest_source_time.toISOString() : new Date(row.latest_source_time).toISOString();
+      const lastSourceTime = this.lastSourceTimeByTicker.get(row.ticker);
+      if (!lastSourceTime || latestSourceTime <= lastSourceTime) {
+        continue;
+      }
+
+      ranges.push({
+        ticker: row.ticker,
+        start_exclusive_time: lastSourceTime,
+        end_inclusive_time: latestSourceTime,
+      });
+    }
+
+    if (ranges.length === 0) {
+      return 0;
+    }
+
+    const rows = await this.loadSourceRowsInRanges(ranges);
+    if (rows.length === 0) {
+      return 0;
+    }
+
+    const sourceCandles = rows.map((row) => candleForDbFromStoredRow(row, { requireCompleteCvd: true }));
+    const accepted = this.rollingWindow.addCandles(sourceCandles);
+    this.recordSourceRows(rows);
+    if (accepted > 0) {
+      console.log(`🔁 Reconciled ${accepted} canonical 1m row(s) from ${SOURCE_TABLE} into ${TARGET_TABLE}`);
+    }
+    return accepted;
+  }
+
   private async ensureInitialized(): Promise<boolean> {
     if (this.initialized) {
       return true;
@@ -235,6 +390,9 @@ export class Candles1h1mAggregator {
 
   private async hydrateFromDatabase(): Promise<boolean> {
     try {
+      this.rollingWindow = this.createRollingWindow();
+      this.lastSourceTimeByTicker.clear();
+
       const latestTargetTimes = await this.loadLatestTargetTimes();
       const recentSourceRows = await this.queryable.query<StoredCandleRow>(HYDRATION_QUERY, [HYDRATION_WINDOW_ROWS]);
 
@@ -245,6 +403,7 @@ export class Candles1h1mAggregator {
       const reconciliation = await this.reconcileFromSource(latestTargetTimes);
       const seedCandles = [...recentSeedCandles];
       this.rollingWindow.seedCandles(seedCandles);
+      this.recordSourceCandles(seedCandles);
 
       const totalSeeded = seedCandles.length + reconciliation.seeded;
       if (totalSeeded > 0) {
@@ -278,11 +437,18 @@ export class Candles1h1mAggregator {
 
     const buffered = this.bufferedBaseCandles;
     this.bufferedBaseCandles = [];
-    return this.rollingWindow.addCandles(buffered);
+    const accepted = this.rollingWindow.addCandles(buffered);
+    this.recordSourceCandles(buffered);
+    return accepted;
   }
 
   private async loadLatestTargetTimes(): Promise<LatestTargetRow[]> {
     const result = await this.queryable.query<LatestTargetRow>(LATEST_TARGET_TIMES_QUERY);
+    return result.rows;
+  }
+
+  private async loadLatestSourceTimes(): Promise<LatestSourceRow[]> {
+    const result = await this.queryable.query<LatestSourceRow>(LATEST_SOURCE_TIMES_QUERY);
     return result.rows;
   }
 
@@ -317,9 +483,11 @@ export class Candles1h1mAggregator {
       if (reconciliationSeedCandles.length > 0) {
         seeded += reconciliationSeedCandles.length;
         this.rollingWindow.seedCandles(reconciliationSeedCandles);
+        this.recordSourceCandles(reconciliationSeedCandles);
       }
       if (reconciliationReplayCandles.length > 0) {
         replayed += this.rollingWindow.addCandles(reconciliationReplayCandles);
+        this.recordSourceCandles(reconciliationReplayCandles);
       }
       if (this.rollingWindow.getStats().pendingCandles >= RECONCILIATION_FLUSH_THRESHOLD) {
         await this.flushPendingCandles();
@@ -371,6 +539,37 @@ export class Candles1h1mAggregator {
     `;
 
     const result = await this.queryable.query<ReconciliationSourceRow>(query, values);
+    return result.rows;
+  }
+
+  private async loadSourceRowsInRanges(ranges: SourceCatchupRange[]): Promise<StoredCandleRow[]> {
+    if (ranges.length === 0) {
+      return [];
+    }
+
+    const values: unknown[] = [];
+    const placeholders = ranges.map((range, index) => {
+      const offset = index * 3;
+      values.push(range.ticker, range.start_exclusive_time, range.end_inclusive_time);
+      return `($${offset + 1}, $${offset + 2}::timestamptz, $${offset + 3}::timestamptz)`;
+    });
+
+    const query = `
+      WITH source_range(ticker, start_exclusive_time, end_inclusive_time) AS (
+        VALUES ${placeholders.join(", ")}
+      )
+      SELECT
+        ${SOURCE_COLUMNS_FROM_SOURCE_TABLE}
+      FROM ${SOURCE_TABLE}
+      JOIN source_range
+        ON source_range.ticker = ${SOURCE_TABLE}.ticker
+      WHERE time = date_trunc('minute', time)
+        AND ${SOURCE_TABLE}.time > source_range.start_exclusive_time
+        AND ${SOURCE_TABLE}.time <= source_range.end_inclusive_time
+      ORDER BY ${SOURCE_TABLE}.ticker ASC, ${SOURCE_TABLE}.time ASC
+    `;
+
+    const result = await this.queryable.query<StoredCandleRow>(query, values);
     return result.rows;
   }
 

--- a/apps-trading/write-node/src/stream/tbbo-1m-aggregator.test.ts
+++ b/apps-trading/write-node/src/stream/tbbo-1m-aggregator.test.ts
@@ -15,7 +15,7 @@ test("flushCompleted retries queued hourly writes during idle periods", async ()
     writeCandlesFn: async () => {},
     hourlyAggregator: {
       initialize: async () => {},
-      addBaseCandles: () => 0,
+      addBaseCandles: async () => 0,
       flushCompleted: async () => {
         flushCompletedCalls++;
       },
@@ -26,4 +26,68 @@ test("flushCompleted retries queued hourly writes during idle periods", async ()
   await aggregator.flushCompleted();
 
   assert.equal(flushCompletedCalls, 1);
+});
+
+test("keeps committed 1m writes even when hourly aggregation fails", async () => {
+  let oneMinuteWrites = 0;
+  let hourlyAddCalls = 0;
+
+  const aggregator = new Tbbo1mAggregator({
+    queryable: {
+      query: async <Row = unknown>() => ({ rows: [] as Row[] }),
+    },
+    writeCandlesFn: async () => {
+      oneMinuteWrites++;
+    },
+    hourlyAggregator: {
+      initialize: async () => {},
+      addBaseCandles: async () => {
+        hourlyAddCalls++;
+        throw new Error("hourly catch-up failed");
+      },
+      flushCompleted: async () => {},
+      flushAll: async () => {},
+    },
+  });
+
+  const success = await (aggregator as unknown as { writeBatch: (batch: unknown[]) => Promise<boolean> }).writeBatch([
+    {
+      key: "ES|2026-03-10T14:00:00.000Z",
+      ticker: "ES",
+      time: "2026-03-10T14:00:00.000Z",
+      candle: {
+        open: 6000,
+        high: 6000,
+        low: 6000,
+        close: 6000,
+        volume: 1,
+        askVolume: 1,
+        bidVolume: 0,
+        unknownSideVolume: 0,
+        sumBidDepth: 1,
+        sumAskDepth: 1,
+        sumSpread: 0,
+        sumMidPrice: 0,
+        sumPriceVolume: 6000,
+        maxTradeSize: 1,
+        largeTradeCount: 0,
+        largeTradeVolume: 0,
+        tradeCount: 1,
+        symbol: "ESH6",
+        currentCvd: 1,
+        metricsOHLC: {
+          cvd: {
+            open: 1,
+            high: 1,
+            low: 1,
+            close: 1,
+          },
+        },
+      },
+    },
+  ]);
+
+  assert.equal(success, true);
+  assert.equal(oneMinuteWrites, 1);
+  assert.equal(hourlyAddCalls, 1);
 });

--- a/apps-trading/write-node/src/stream/tbbo-1m-aggregator.ts
+++ b/apps-trading/write-node/src/stream/tbbo-1m-aggregator.ts
@@ -37,7 +37,7 @@ interface Queryable {
 
 interface HourlyAggregatorLike {
   initialize(): Promise<void>;
-  addBaseCandles(candles: CandleForDb[]): number;
+  addBaseCandles(candles: CandleForDb[]): Promise<number>;
   flushCompleted(): Promise<void>;
   flushAll(): Promise<void>;
 }
@@ -253,12 +253,16 @@ export class Tbbo1mAggregator {
     try {
       await this.writeCandlesFn(this.queryable, TARGET_TABLE, batch);
       this.candlesWritten += batch.length;
-      this.hourlyAggregator.addBaseCandles(batch);
-      await this.hourlyAggregator.flushCompleted();
-      return true;
     } catch (error) {
       console.error("❌ Failed to write 1m candles:", error);
       return false;
     }
+    try {
+      await this.hourlyAggregator.addBaseCandles(batch);
+      await this.hourlyAggregator.flushCompleted();
+    } catch (error) {
+      console.error(`❌ Failed to advance ${TARGET_TABLE} -> candles_1h_1m hourly aggregation:`, error);
+    }
+    return true;
   }
 }

--- a/lib/db-timescale/generated/contracts/db-schema.json
+++ b/lib/db-timescale/generated/contracts/db-schema.json
@@ -134,6 +134,11 @@
       "column": "unknown_volume",
       "nullable": false,
       "type": "number"
+    },
+    {
+      "column": "minute",
+      "nullable": false,
+      "type": "number"
     }
   ],
   "candles_1m_1s": [
@@ -269,6 +274,11 @@
     },
     {
       "column": "unknown_volume",
+      "nullable": false,
+      "type": "number"
+    },
+    {
+      "column": "second",
       "nullable": false,
       "type": "number"
     }

--- a/lib/db-timescale/generated/typescript/db-types.ts
+++ b/lib/db-timescale/generated/typescript/db-types.ts
@@ -29,6 +29,7 @@ export interface Candles1h1mRow {
   "sum_ask_depth": number;
   "sum_price_volume": number;
   "unknown_volume": number;
+  "minute": number;
 }
 
 export interface Candles1m1sRow {
@@ -59,6 +60,7 @@ export interface Candles1m1sRow {
   "sum_ask_depth": number;
   "sum_price_volume": number;
   "unknown_volume": number;
+  "second": number;
 }
 
 export interface TimescaleDbSchema {

--- a/lib/db-timescale/migrations/202603171015__add_candle_sample_offsets.sql
+++ b/lib/db-timescale/migrations/202603171015__add_candle_sample_offsets.sql
@@ -1,0 +1,21 @@
+ALTER TABLE public.candles_1m_1s
+    ADD COLUMN IF NOT EXISTS second smallint;
+
+UPDATE public.candles_1m_1s
+SET second = EXTRACT(SECOND FROM "time" AT TIME ZONE 'UTC')::smallint
+WHERE second IS NULL;
+
+ALTER TABLE public.candles_1m_1s
+    ADD CONSTRAINT candles_1m_1s_second_range CHECK (second BETWEEN 0 AND 59),
+    ALTER COLUMN second SET NOT NULL;
+
+ALTER TABLE public.candles_1h_1m
+    ADD COLUMN IF NOT EXISTS minute smallint;
+
+UPDATE public.candles_1h_1m
+SET minute = EXTRACT(MINUTE FROM "time" AT TIME ZONE 'UTC')::smallint
+WHERE minute IS NULL;
+
+ALTER TABLE public.candles_1h_1m
+    ADD CONSTRAINT candles_1h_1m_minute_range CHECK (minute BETWEEN 0 AND 59),
+    ALTER COLUMN minute SET NOT NULL;

--- a/lib/db-timescale/migrations/202603171055__sync_candle_sample_offsets.sql
+++ b/lib/db-timescale/migrations/202603171055__sync_candle_sample_offsets.sql
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION public.sync_candles_1m_1s_second()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.second := EXTRACT(SECOND FROM NEW."time" AT TIME ZONE 'UTC')::smallint;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS candles_1m_1s_sync_second ON public.candles_1m_1s;
+
+CREATE TRIGGER candles_1m_1s_sync_second
+BEFORE INSERT OR UPDATE ON public.candles_1m_1s
+FOR EACH ROW
+EXECUTE FUNCTION public.sync_candles_1m_1s_second();
+
+CREATE OR REPLACE FUNCTION public.sync_candles_1h_1m_minute()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.minute := EXTRACT(MINUTE FROM NEW."time" AT TIME ZONE 'UTC')::smallint;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS candles_1h_1m_sync_minute ON public.candles_1h_1m;
+
+CREATE TRIGGER candles_1h_1m_sync_minute
+BEFORE INSERT OR UPDATE ON public.candles_1h_1m
+FOR EACH ROW
+EXECUTE FUNCTION public.sync_candles_1h_1m_minute();

--- a/lib/db-timescale/queries/candles/upsert_candles.sql
+++ b/lib/db-timescale/queries/candles/upsert_candles.sql
@@ -1,6 +1,8 @@
 -- name: upsert_candles_batch
 -- Canonical upsert contract for candle rows.
 -- Replace {{TABLE_NAME}} with target table (for example candles_1m_1s or candles_1h_1m).
+-- Replace {{TIME_OFFSET_COLUMN}} with the table's explicit sample offset column
+-- (`second` for candles_1m_1s, `minute` for candles_1h_1m).
 -- Expand VALUES tuples as needed for batched inserts.
 INSERT INTO {{TABLE_NAME}} (
   time, ticker, symbol,
@@ -9,10 +11,11 @@ INSERT INTO {{TABLE_NAME}} (
   cvd_open, cvd_high, cvd_low, cvd_close,
   vd, vd_ratio, book_imbalance, price_pct, divergence,
   trades, max_trade_size, big_trades, big_volume,
-  sum_bid_depth, sum_ask_depth, sum_price_volume, unknown_volume
+  sum_bid_depth, sum_ask_depth, sum_price_volume, unknown_volume,
+  {{TIME_OFFSET_COLUMN}}
 )
 VALUES
-  -- ($1, $2, ... $27), ($28, ...), ...
+  -- ($1, $2, ... $28), ($29, ...), ...
 ON CONFLICT (ticker, time) DO UPDATE SET
   symbol = EXCLUDED.symbol,
   open = EXCLUDED.open,
@@ -38,4 +41,5 @@ ON CONFLICT (ticker, time) DO UPDATE SET
   sum_bid_depth = EXCLUDED.sum_bid_depth,
   sum_ask_depth = EXCLUDED.sum_ask_depth,
   sum_price_volume = EXCLUDED.sum_price_volume,
-  unknown_volume = EXCLUDED.unknown_volume;
+  unknown_volume = EXCLUDED.unknown_volume,
+  {{TIME_OFFSET_COLUMN}} = EXCLUDED.{{TIME_OFFSET_COLUMN}};

--- a/lib/db-timescale/schema/current.sql
+++ b/lib/db-timescale/schema/current.sql
@@ -28,6 +28,34 @@ SET row_security = off;
 
 
 
+--
+-- Name: sync_candles_1h_1m_minute(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.sync_candles_1h_1m_minute() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    NEW.minute := EXTRACT(MINUTE FROM NEW."time" AT TIME ZONE 'UTC')::smallint;
+    RETURN NEW;
+END;
+$$;
+
+
+--
+-- Name: sync_candles_1m_1s_second(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.sync_candles_1m_1s_second() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    NEW.second := EXTRACT(SECOND FROM NEW."time" AT TIME ZONE 'UTC')::smallint;
+    RETURN NEW;
+END;
+$$;
+
+
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -134,6 +162,20 @@ CREATE INDEX idx_candles_1h_1m_time_desc ON public.candles_1h_1m USING btree ("t
 --
 
 CREATE INDEX idx_candles_1m_1s_time_desc ON public.candles_1m_1s USING btree ("time" DESC);
+
+
+--
+-- Name: candles_1h_1m candles_1h_1m_sync_minute; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER candles_1h_1m_sync_minute BEFORE INSERT OR UPDATE ON public.candles_1h_1m FOR EACH ROW EXECUTE FUNCTION public.sync_candles_1h_1m_minute();
+
+
+--
+-- Name: candles_1m_1s candles_1m_1s_sync_second; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER candles_1m_1s_sync_second BEFORE INSERT OR UPDATE ON public.candles_1m_1s FOR EACH ROW EXECUTE FUNCTION public.sync_candles_1m_1s_second();
 
 
 --

--- a/lib/db-timescale/schema/current.sql
+++ b/lib/db-timescale/schema/current.sql
@@ -63,7 +63,9 @@ CREATE TABLE public.candles_1h_1m (
     sum_bid_depth double precision DEFAULT 0 NOT NULL,
     sum_ask_depth double precision DEFAULT 0 NOT NULL,
     sum_price_volume double precision DEFAULT 0 NOT NULL,
-    unknown_volume double precision DEFAULT 0 NOT NULL
+    unknown_volume double precision DEFAULT 0 NOT NULL,
+    minute smallint NOT NULL,
+    CONSTRAINT candles_1h_1m_minute_range CHECK (((minute >= 0) AND (minute <= 59)))
 );
 
 
@@ -98,7 +100,9 @@ CREATE TABLE public.candles_1m_1s (
     sum_bid_depth double precision DEFAULT 0 NOT NULL,
     sum_ask_depth double precision DEFAULT 0 NOT NULL,
     sum_price_volume double precision DEFAULT 0 NOT NULL,
-    unknown_volume double precision DEFAULT 0 NOT NULL
+    unknown_volume double precision DEFAULT 0 NOT NULL,
+    second smallint NOT NULL,
+    CONSTRAINT candles_1m_1s_second_range CHECK (((second >= 0) AND (second <= 59)))
 );
 
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,9 +432,15 @@ importers:
 
   apps-trading/write-node:
     dependencies:
+      '@lib/common':
+        specifier: workspace:*
+        version: link:../../lib/common
       '@lib/db-timescale':
         specifier: workspace:*
         version: link:../../lib/db-timescale
+      '@lib/db-trading':
+        specifier: workspace:*
+        version: link:../../lib/db-trading
       cors:
         specifier: ^2.8.5
         version: 2.8.6


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->



## Summary
- add a forward Timescale migration for `candles_1m_1s.second` and `candles_1h_1m.minute`, backfill existing rows from UTC timestamps, and update the schema snapshot/generated contracts
- update the shared candle writer to derive and persist the new UTC sample offset columns on every upsert
- tighten `write-node` candle adapters to depend on generated `@lib/db-timescale` row types and add focused tests for the new write behavior
- add a follow-up DB compatibility migration that derives `second`/`minute` from `time` inside the database so pre-deploy writers do not fail inserts during rollout
- continuously reconcile `candles_1h_1m` from committed minute-boundary `candles_1m_1s` rows during runtime, including catch-up before newer live handoff rows and periodic DB-backed replay of missed source rows
- keep the historical TBBO batch path aligned with live behavior by advancing `candles_1h_1m` as `candles_1m_1s` rows are written instead of waiting for a separate rebuild step
- add a lag-aware `/api/v1/health` response plus in-process unhealthy/recovery logging so infrastructure can detect stale `candles_1h_1m` automatically instead of relying on manual DB inspection
- automatically remediate persistent hourly lag by logging the event to `sqlLogAdd`, sending SMS via `sendToMyselfSMS`, and exiting non-zero so the hosting platform can restart the writer

## Testing
- `pnpm --filter write-node build`
- `pnpm --filter write-node exec tsx --test src/lib/health/hourly-lag-remediation.test.ts src/lib/health/write-pipeline-health.test.ts src/stream/tbbo-1m-aggregator.test.ts src/stream/candles-1h-1m-aggregator.test.ts src/lib/trade/db-writer.test.ts src/lib/trade/canonical-candle.test.ts`
- `pnpm --filter @lib/db-timescale db:verify`
- `pnpm build`


<div><a href="https://cursor.com/agents/bc-74bef111-9d58-4c7c-a35e-c420fe393e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74bef111-9d58-4c7c-a35e-c420fe393e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>




<div><a href="https://cursor.com/agents/bc-74bef111-9d58-4c7c-a35e-c420fe393e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74bef111-9d58-4c7c-a35e-c420fe393e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>




<div><a href="https://cursor.com/agents/bc-74bef111-9d58-4c7c-a35e-c420fe393e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74bef111-9d58-4c7c-a35e-c420fe393e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74bef111-9d58-4c7c-a35e-c420fe393e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74bef111-9d58-4c7c-a35e-c420fe393e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

